### PR TITLE
dependabot.ymlを作成し、packages/frontend, packages/backend, root配下のライブラリのバージョンを管理する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
   
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/packages/backend"
     schedule:
       interval: "daily"
   
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/packages/frontend"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# 変更領域
- [x] backend
- [x] frontend

# やったこと
- dependabotを機能させるようにし、ライブラリバージョンアップを見逃さないようにする
  - 一旦dailyにしてちゃんと検知しているかを観察する

# package-ecosystemについて
pnpmプロジェクトでもpackage-ecosystem: "npm"を使用するのは問題ないらしい。理由は以下。


> ## なぜ問題ないのか
> **1. Dependabotの公式仕様**
Dependabotはpnpmプロジェクトでもnpmエコシステムとして扱います
これは公式ドキュメントでも推奨されている方法です
> 
> **2. pnpmとnpmの互換性**
pnpmはnpmと同じpackage.json形式を使用
package-lock.jsonの代わりにpnpm-lock.yamlを使用するだけで、基本的な依存関係管理は同じ
> 
> **3. 実際の動作**
Dependabotはpackage.jsonファイルを読み取り、依存関係の更新を検出
pnpmのlockファイル形式に関係なく、依存関係の更新は正常に検出されます

CIも通っているし問題なさそうと判断
