### PR TITLE
CI/CDパイプラインでのマイグレーション整合性チェック強化する

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -42,9 +42,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
       
+      - name: Verify migration files consistency
+        run: |
+          # スキーマに基づいてマイグレーションを生成し、差分をチェック
+          pnpm db:generate
+          
+          # 生成されたファイルがコミット済みファイルと一致するかチェック
+          if [ -n "$(git status --porcelain drizzle/)" ]; then
+            echo "❌ Migration files are not up to date with schema changes"
+            echo "Generated files differ from committed files:"
+            git status --porcelain drizzle/
+            echo ""
+            echo "Please run 'pnpm db:generate' and commit the generated files"
+            exit 1
+          fi
+          
+          echo "✅ Migration files are consistent with schema"
+        working-directory: packages/backend
+
       - name: Setup test database
         run: |
-          pnpm db:generate
           pnpm db:migrate
         working-directory: packages/backend
         env:


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
本番DBでマイグレーションエラーが発生した。原因はDrizzleのマイグレーションファイルがローカルで生成されていなかったためである。スキーマ変更後にpnpm db:generateを実行せずにコミットしてしまい、本番環境でスキーマとマイグレーションファイルの不整合が発生した。

## やったこと
CI/CDパイプラインでマイグレーション整合性チェックを追加した。↓

.github/workflows/test-backend.yml
- テストデータベースセットアップ前に「Verify migration files consistency」ステップを追加
  - pnpm db:generateを実行し、生成されたファイルとコミット済みファイルの差分をチェック
  - 差分がある場合はCIを失敗させ、開発者にマイグレーションファイルの生成を促す

## 確認したこと(デグレチェック)
なし

## リリース時本番環境で確認すること
なし
