### PR TITLE
Fix unused variable in failing test

### DIFF
--- a/packages/backend/__tests__/infrastructure/repository/StateRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/StateRepository.test.ts
@@ -89,6 +89,24 @@ describe("StateRepository Tests", () => {
       // assert
       expect(actual).toBeNull();
     });
+
+    it("期限切れのOAuth stateでも取得できること（期限チェックはアプリケーション層で行う）", async () => {
+      // arrange
+      const expiredStateRecord = createExpiredOauthStateTableFixture();
+      await insertToDatabase(schema.oauthState, expiredStateRecord);
+
+      // act
+      const actual = await stateRepository.getBySessionId(expiredStateRecord.sessionId);
+
+      // assert
+      expect(actual).not.toBeNull();
+      expect(actual).toEqual({
+        sessionId: expiredStateRecord.sessionId,
+        state: expiredStateRecord.state,
+        nonce: expiredStateRecord.nonce,
+        expiresAt: expiredStateRecord.expiresAt
+      });
+    });
   });
 
   describe("delete", () => {


### PR DESCRIPTION
## 変更領域
バックエンド (テストコード)

## 背景
`createExpiredOauthStateTableFixture`が定義されているが使用されていないというlintエラーが発生していました。このエラーを解消するため、単に削除するのではなく、期限切れのOAuth stateに関するテストカバレッジを向上させる方針で修正を行いました。

## やったこと
- `createExpiredOauthStateTableFixture`が未使用であるというlintエラーを解消。
- `StateRepository`のテストに、期限切れのOAuth stateでも取得できることを確認するテストケースを追加。
- 追加したテストケースで`createExpiredOauthStateTableFixture`を使用。

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
既存機能への影響がないことを確認しました。lintエラーが解消されたことを確認しました。

## リリース時本番環境で確認すること
なし (テストコードの変更のため)

---
<a href="https://cursor.com/background-agent?bcId=bc-cbe6ab58-2db1-4e29-80d4-3b1d4db1e8b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbe6ab58-2db1-4e29-80d4-3b1d4db1e8b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

