### PR TITLE
fix: フレーキーなDiscordTokensテストのcreatedAt時刻モックを修正

### DIFF
--- a/packages/backend/__tests__/domain/DiscordTokens.test.ts
+++ b/packages/backend/__tests__/domain/DiscordTokens.test.ts
@@ -9,9 +9,10 @@ import { UserID } from "../../src/domain/User";
 import { CreatedAt } from "../../src/utils/CreatedAt";
 
 const MOCK_UUID = "00000000-0000-0000-0000-000000";
-const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z").getTime();
+const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z");
 
-vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW);
+// Mock system time to ensure consistent Date creation
+vi.setSystemTime(MOCK_NOW);
 
 vi.mock("../../src/domain/models/User", () => {
   return {

--- a/packages/backend/__tests__/domain/DiscordTokens.test.ts
+++ b/packages/backend/__tests__/domain/DiscordTokens.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AccessToken,
   DiscordTokens,
@@ -9,10 +9,7 @@ import { UserID } from "../../src/domain/User";
 import { CreatedAt } from "../../src/utils/CreatedAt";
 
 const MOCK_UUID = "00000000-0000-0000-0000-000000";
-const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z");
-
-// Mock system time to ensure consistent Date creation
-vi.setSystemTime(MOCK_NOW);
+const MOCK_NOW_DATE = new Date("2025-01-01T00:00:00.000Z");
 
 vi.mock("../../src/domain/models/User", () => {
   return {
@@ -22,6 +19,15 @@ vi.mock("../../src/domain/models/User", () => {
       }))
     }
   };
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(MOCK_NOW_DATE);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("DiscordTokensDomainTest", () => {

--- a/packages/backend/__tests__/domain/User.test.ts
+++ b/packages/backend/__tests__/domain/User.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Department,
   DiscordID,
@@ -9,9 +9,7 @@ import {
 import { CreatedAt } from "../../src/utils/CreatedAt";
 
 const MOCK_UUID = "00000000-0000-0000-0000-000000";
-const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z").getTime();
-
-vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW);
+const MOCK_NOW_DATE = new Date("2025-01-01T00:00:00.000Z");
 
 vi.mock("../../src/utils/UUID", () => {
   return {
@@ -21,6 +19,15 @@ vi.mock("../../src/utils/UUID", () => {
       }))
     }
   };
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(MOCK_NOW_DATE);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("UserDomainTest", () => {


### PR DESCRIPTION
- vi.setSystemTime()を使用してnew Date()も含めて時刻を固定
- Date.now()のみのモックでは不十分だった問題を解決

## 変更領域
フロントエンドもしくはバックエンド、または両方を明記してください。

## 背景
なぜこのPRが発生したか・この変更が必要なのかを明記してください

## やったこと
箇条書きでやったことを明記してください

## 動作確認動画(スクリーンショット)
なしであればなしと明記してください

## 確認したこと(デグレチェック)
既存機能に影響がないことを確認した旨を明記してください

## リリース時本番環境で確認すること
リリース前後で確認すべきことを明記してください
