### PR TITLE
ローカルでテスト実行前のDB自動マイグレーション機能を追加

### DIFF
--- a/packages/backend/__tests__/setup/test-setup.ts
+++ b/packages/backend/__tests__/setup/test-setup.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+
+import { exec } from "child_process";
+import postgres from "postgres";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+/**
+ * テスト環境のデータベースセットアップ
+ * テスト実行前に自動でマイグレーションを実行する
+ */
+export async function setup() {
+  try {
+    console.log("🧪 Setting up test environment...");
+
+    // テスト環境用のDB接続設定
+    const testDatabaseUrl =
+      process.env.TEST_DATABASE_URL ||
+      process.env.DATABASE_URL ||
+      "postgres://postgres:postgres@db.localtest.me:5432/main";
+
+    console.log("📡 Connecting to test database...");
+
+    // テスト用DB接続を作成（テストでは常に直接PostgreSQL接続を使用）
+    const sql = postgres(testDatabaseUrl);
+
+    // 接続テスト
+    console.log("🔍 Testing database connection...");
+    await sql`SELECT 1`;
+    console.log("✅ Database connection successful");
+
+    // マイグレーション実行
+    console.log("📝 Running test database migrations...");
+    const { stdout, stderr } = await execAsync("npx drizzle-kit migrate", {
+      env: {
+        ...process.env,
+        DATABASE_URL: testDatabaseUrl,
+        NODE_ENV: "test"
+      },
+      cwd: process.cwd()
+    });
+
+    if (stderr) {
+      console.warn("⚠️ Migration warnings:", stderr);
+    }
+    if (stdout) {
+      console.log("📋 Migration output:", stdout);
+    }
+
+    console.log("✅ Test database setup completed successfully");
+
+    // テーブルの存在確認
+    console.log("🔍 Verifying tables...");
+    try {
+      const result = await sql`
+        SELECT table_name 
+        FROM information_schema.tables 
+        WHERE table_schema = 'public'
+        ORDER BY table_name
+      `;
+      console.log(
+        "📊 Available tables:",
+        result.map((r) => r.table_name).join(", ")
+      );
+    } catch (error) {
+      console.warn("⚠️ Could not verify tables:", error);
+    }
+
+    // 接続をクリーンアップ
+    await sql.end();
+
+    console.log("🎉 Test environment setup complete!");
+  } catch (error) {
+    console.error("❌ Test setup failed:", error);
+
+    if (error instanceof Error) {
+      console.error("Error message:", error.message);
+      console.error("Stack trace:", error.stack);
+    }
+
+    throw error; // テストセットアップが失敗した場合はテスト実行を停止
+  }
+}
+
+/**
+ * テスト終了時のクリーンアップ
+ */
+export async function teardown() {
+  console.log("🧹 Test environment teardown completed");
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,6 +8,7 @@
     "test": "vitest",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
+    "test:setup": "tsx __tests__/setup/test-setup.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "db:generate": "drizzle-kit generate",

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["**/__tests__/**/*.test.ts"],
+    globalSetup: ["./__tests__/setup/test-setup.ts"],
     // リポジトリテストのみ順次実行、他は並列実行
     poolMatchGlobs: [
       // リポジトリテストは順次実行


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
ローカル環境でのテスト実行時、データベースのマイグレーションが事前に実行されていないため、リポジトリテストが失敗する問題があった。CIでは正常に動作しているが、開発者がローカルでテストを実行する際に毎回手動でマイグレーションを実行する必要があり、開発効率が低下していた。

## やったこと
- __tests__/setup/test-setup.tsを新規作成
  - テスト実行前にデータベースのマイグレーションを自動実行する機能を実装
  - PostgreSQL直接接続を使用してテスト環境専用のDB接続を構築
  - マイグレーション実行後のテーブル存在確認機能を追加

## 別でやること
test-setupとconnection.tsのリファクタリング

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
テストが通ること

## リリース時本番環境で確認すること
なし
