### PR TITLE
refactor: remove getValue methods from value objects

### DIFF
--- a/packages/backend/__tests__/testing/table_assert/AssertEqualUserTable.ts
+++ b/packages/backend/__tests__/testing/table_assert/AssertEqualUserTable.ts
@@ -13,11 +13,11 @@ export const assertEqualUserTable = (
 ): void => {
   const expectedRecord = {
     id: expectedUser.userID.value.value,
-    discordId: expectedUser.discordID.getValue(),
+    discordId: expectedUser.discordID.value,
     discordUserName: expectedUser.discordUserName,
     discordAvatar: expectedUser.discordAvatar,
-    faculty: expectedUser.faculty?.getValue() ?? null,
-    department: expectedUser.department?.getValue() ?? null,
+    faculty: expectedUser.faculty?.value ?? null,
+    department: expectedUser.department?.value ?? null,
     createdAt: expectedUser.createdAt.value
   };
 

--- a/packages/backend/src/application/dtos/auth.dto.ts
+++ b/packages/backend/src/application/dtos/auth.dto.ts
@@ -33,7 +33,7 @@ export const toUserDTO = (user: User): UserDTO => {
     id: user.userID.value.value,
     discordUserName: user.discordUserName,
     discordAvatar: user.discordAvatar,
-    faculty: user.faculty?.getValue() ?? "",
-    department: user.department?.getValue() ?? ""
+    faculty: user.faculty?.value ?? "",
+    department: user.department?.value ?? ""
   };
 };

--- a/packages/backend/src/domain/User.ts
+++ b/packages/backend/src/domain/User.ts
@@ -79,40 +79,28 @@ export class UserID {
 }
 
 export class DiscordID {
-  private constructor(private readonly value: string) {}
+  private constructor(readonly value: string) {}
 
   static from(value: string): DiscordID {
     discordIDSchema.parse(value);
     return new DiscordID(value);
   }
-
-  getValue(): string {
-    return this.value;
-  }
 }
 
 export class Faculty {
-  private constructor(private readonly value: string) {}
+  private constructor(readonly value: string) {}
 
   static from(value: string): Faculty {
     facultySchema.parse(value);
     return new Faculty(value);
   }
-
-  getValue(): string {
-    return this.value;
-  }
 }
 
 export class Department {
-  private constructor(private readonly value: string) {}
+  private constructor(readonly value: string) {}
 
   static from(value: string): Department {
     departmentSchema.parse(value);
     return new Department(value);
-  }
-
-  getValue(): string {
-    return this.value;
   }
 }

--- a/packages/backend/src/infrastructure/repositories/UserRepository.ts
+++ b/packages/backend/src/infrastructure/repositories/UserRepository.ts
@@ -27,7 +27,7 @@ export class UserRepository implements UserRepositoryInterface {
     discordID: DiscordID
   ): Promise<UserRecord | null> {
     const user = await db.query.user.findFirst({
-      where: eq(userSchema.discordId, discordID.getValue())
+      where: eq(userSchema.discordId, discordID.value)
     });
 
     if (!user) return null;
@@ -58,11 +58,11 @@ export class UserRepository implements UserRepositoryInterface {
   async save(user: User): Promise<void> {
     await db.insert(userSchema).values({
       id: user.userID.value.value,
-      discordId: user.discordID.getValue(),
+      discordId: user.discordID.value,
       discordUserName: user.discordUserName,
       discordAvatar: user.discordAvatar,
-      faculty: user.faculty?.getValue() ?? null,
-      department: user.department?.getValue() ?? null,
+      faculty: user.faculty?.value ?? null,
+      department: user.department?.value ?? null,
       createdAt: user.createdAt.value
     });
   }


### PR DESCRIPTION
## 概要
値オブジェクトの `getValue` メソッドを削除し、`value` プロパティを直接アクセスできるように変更しました。

## 変更内容
- `DiscordID`, `Faculty`, `Department` クラスの `value` プロパティを public に変更
- これらのクラスから `getValue()` メソッドを削除
- `getValue()` を呼び出していた全ての箇所を `.value` プロパティへの直接アクセスに変更

## 影響範囲
- `packages/backend/src/domain/User.ts` (値オブジェクト定義)
- `packages/backend/__tests__/testing/table_assert/AssertEqualUserTable.ts` (テストアサーション)
- `packages/backend/src/application/dtos/auth.dto.ts` (DTO変換)
- `packages/backend/src/infrastructure/repositories/UserRepository.ts` (リポジトリ実装)

## 検証
- TypeScript コンパイルエラー無し
- ESLint チェック通過
- 既存のテスト構造は維持

## 変更の詳細
- 4ファイル変更、12行追加、24行削除
- 全ての `getValue()` 呼び出しを `.value` プロパティアクセスに置換
- 値オブジェクトのAPIがよりシンプルで直接的になりました