### PR TITLE
[ドメイン]WeeklyAvailablePointsドメインモデルの作成

### DIFF
--- a/packages/backend/__tests__/domain/WeeklyAvailablePoints.test.ts
+++ b/packages/backend/__tests__/domain/WeeklyAvailablePoints.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UserID } from "../../src/domain/User";
+import {
+  AvailablePoints,
+  InitializedAt,
+  WeeklyAvailablePoints,
+  WeeklyAvailablePointsID
+} from "../../src/domain/WeeklyAvailablePoints";
+import { CreatedAt } from "../../src/utils/CreatedAt";
+import { UUID } from "../../src/utils/UUID";
+
+const MOCK_WEEKLY_AVAILABLE_POINTS_ID = UUID.new().value;
+const MOCK_NOW_DATE = new Date("2025-01-01T00:00:00.000Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(MOCK_NOW_DATE);
+
+  vi.spyOn(WeeklyAvailablePointsID, "new").mockReturnValue(
+    new (class {
+      constructor(public readonly value: UUID) {}
+    })(UUID.from(MOCK_WEEKLY_AVAILABLE_POINTS_ID))
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("WeeklyAvailablePointsDomainTest", () => {
+  const userID = UserID.new();
+  const initializedAt = InitializedAt.new();
+
+  describe("WeeklyAvailablePointsドメインの作成", () => {
+    it("WeeklyAvailablePointsを作成できること", () => {
+      // arrange
+      const expected = WeeklyAvailablePoints.reconstruct(
+        WeeklyAvailablePointsID.new(),
+        userID,
+        initializedAt,
+        AvailablePoints.new(),
+        CreatedAt.new()
+      );
+
+      // act
+      const actual = WeeklyAvailablePoints.create(userID, initializedAt);
+
+      // assert
+      expect(actual).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/backend/src/domain/WeeklyAvailablePoints.ts
+++ b/packages/backend/src/domain/WeeklyAvailablePoints.ts
@@ -1,0 +1,72 @@
+import { CreatedAt } from "../utils/CreatedAt";
+import { UUID } from "../utils/UUID";
+import type { UserID } from "./User";
+
+const WEEKLY_AVAILABLE_POINTS = 400;
+
+export class WeeklyAvailablePoints {
+  private constructor(
+    readonly weeklyAvailablePointsID: WeeklyAvailablePointsID,
+    readonly userID: UserID,
+    readonly initializedAt: InitializedAt,
+    readonly availablePoints: AvailablePoints,
+    readonly createdAt: CreatedAt
+  ) {}
+
+  static create(
+    userID: UserID,
+    initializedAt: InitializedAt
+  ): WeeklyAvailablePoints {
+    return new WeeklyAvailablePoints(
+      WeeklyAvailablePointsID.new(),
+      userID,
+      initializedAt,
+      AvailablePoints.new(),
+      CreatedAt.new()
+    );
+  }
+
+  static reconstruct(
+    weeklyAvailablePointsID: WeeklyAvailablePointsID,
+    userID: UserID,
+    initializedAt: InitializedAt,
+    availablePoints: AvailablePoints,
+    createdAt: CreatedAt
+  ): WeeklyAvailablePoints {
+    return new WeeklyAvailablePoints(
+      weeklyAvailablePointsID,
+      userID,
+      initializedAt,
+      availablePoints,
+      createdAt
+    );
+  }
+}
+
+export class WeeklyAvailablePointsID {
+  private constructor(readonly value: UUID) {}
+
+  static new(): WeeklyAvailablePointsID {
+    return new WeeklyAvailablePointsID(UUID.new());
+  }
+
+  static from(value: string): WeeklyAvailablePointsID {
+    return new WeeklyAvailablePointsID(UUID.from(value));
+  }
+}
+
+export class InitializedAt {
+  private constructor(readonly value: Date) {}
+
+  static new(): InitializedAt {
+    return new InitializedAt(new Date());
+  }
+}
+
+export class AvailablePoints {
+  private constructor(readonly value: number) {}
+
+  static new(): AvailablePoints {
+    return new AvailablePoints(WEEKLY_AVAILABLE_POINTS);
+  }
+}


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
`WeeklyAvailablePoints`ドメインが必要な理由は、ユニポスシステムにおける週次ポイント制限機能を適切に管理するためである。
このプロダクトでは、ユーザーが他のメンバーに感謝を伝える際にポイントを送る仕組みがあるが、無制限にポイントを送れてしまうとシステムの価値が薄れてしまう。そこで、毎週400ポイントという制限を設けることで、ユーザーが本当に感謝したい場面でポイントを使うよう促している。
この週次制限を実現するには、単純に数値を保持するだけでは不十分だ。ユーザーがポイントを送るたびに残りポイントを減算し、一週間経過したら再び400ポイントにリセットする必要がある。また、いつリセットされたかを正確に記録しておかなければ、適切なタイミングでの更新ができない。
WeeklyAvailablePointsドメインは、こうした複雑な状態管理とビジネスルールの実装を担っている。ドメイン駆動設計の原則に従い、ポイント管理に関するロジックを一箇所に集約することで、システム全体の整合性を保っている。

## やったこと
- `WeeklyAvailablePoints`ドメインの作成
  - テストの作成

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
テストが通ること

## リリース時本番環境で確認すること
なし
