### PR TITLE
[UseCase]DiscordAuthInitiateUseCaseクラスの作成

### DIFF
--- a/packages/backend/__tests__/application/services/DiscordOIDCService.test.ts
+++ b/packages/backend/__tests__/application/services/DiscordOIDCService.test.ts
@@ -129,62 +129,6 @@ describe("DiscordOIDCService Tests", () => {
     vi.restoreAllMocks();
   });
 
-  describe("generateAuthUrl", () => {
-    it("正常にOAuth認証URLを生成できること", async () => {
-      // Arrange
-      const expectedExpiresAt = new Date(Date.now() + 15 * 60 * 1000);
-      mocks.stateRepository.save.mockResolvedValue(undefined);
-
-      // Act
-      const result = await service.generateAuthUrl(mocks.context);
-
-      // Assert
-      expect(result).toMatchObject({
-        authUrl: expect.stringContaining(
-          "https://discord.com/oauth2/authorize"
-        ),
-        state: expect.any(String),
-        sessionId: expect.any(String)
-      });
-
-      expect(result.authUrl).toContain(`client_id=${MOCK_CLIENT_ID}`);
-      expect(result.authUrl).toContain("response_type=code");
-      expect(result.authUrl).toContain(
-        `redirect_uri=${encodeURIComponent(`${MOCK_BASE_URL}/api/auth/callback`)}`
-      );
-      expect(result.authUrl).toContain("scope=identify");
-      expect(result.authUrl).toContain(`state=${result.state}`);
-      expect(result.authUrl).toContain("code_challenge_method=S256");
-
-      expect(mocks.stateRepository.save).toHaveBeenCalledWith(
-        result.sessionId,
-        result.state,
-        expect.any(String), // nonce
-        expect.any(String), // codeVerifier
-        expect.any(Date)
-      );
-
-      // 保存された有効期限が15分後であることを確認
-      const saveCall = mocks.stateRepository.save.mock.calls[0];
-      const savedExpiresAt = saveCall[4] as Date;
-      expect(savedExpiresAt.getTime()).toBeCloseTo(
-        expectedExpiresAt.getTime(),
-        -3
-      ); // 3桁の精度で比較
-    });
-
-    it("stateRepositoryでエラーが発生した場合、例外が発生すること", async () => {
-      // Arrange
-      const error = new Error("Database error");
-      mocks.stateRepository.save.mockRejectedValue(error);
-
-      // Act & Assert
-      await expect(service.generateAuthUrl(mocks.context)).rejects.toThrow(
-        "Database error"
-      );
-    });
-  });
-
   describe("exchangeCodeForTokens", () => {
     const mockTokenResponse: DiscordOIDCTokenResponse = {
       access_token: MOCK_ACCESS_TOKEN,

--- a/packages/backend/__tests__/application/use-case/DiscordAuthInitiateUseCase.test.ts
+++ b/packages/backend/__tests__/application/use-case/DiscordAuthInitiateUseCase.test.ts
@@ -1,0 +1,91 @@
+import type { Context } from "hono";
+import { afterEach, describe, expect, it } from "vitest";
+import * as schema from "../../../database/schema";
+import { DiscordAuthInitiateUseCase } from "../../../src/application/use-case/discord-auth/DiscordAuthInitiateUseCase";
+import { StateRepository } from "../../../src/infrastructure/repositories/StateRepository";
+import { deleteFromDatabase } from "../../testing/utils/GenericTableHelper";
+
+const MOCK_CLIENT_ID = "test_client_id";
+const MOCK_BASE_URL = "https://api.test.com";
+
+const mockContext: Context = {
+  env: {
+    DISCORD_CLIENT_ID: MOCK_CLIENT_ID,
+    BASE_URL: MOCK_BASE_URL
+  }
+} as Context;
+
+describe("DiscordAuthInitiateUseCase Tests", () => {
+  const discordAuthInitiateUseCase = new DiscordAuthInitiateUseCase(
+    new StateRepository()
+  );
+
+  afterEach(async () => {
+    await deleteFromDatabase(schema.oauthState);
+  });
+
+  describe("execute", () => {
+    /**
+     * Discord認証の初期化処理のテストケース
+     *
+     * @description Discord認証URLとセッションIDの生成、および適切な値の検証とDBへの保存確認を行う
+     *
+     * **Arrange（準備）**
+     * - 期待するURLパラメータの定義
+     * - 生成される値の期待長の定義
+     *
+     * **Act（実行）**
+     * - DiscordAuthInitiateUseCaseのexecuteメソッド実行
+     *
+     * **Assert（検証）**
+     * - 生成されたレスポンスの基本構造確認
+     * - URLパラメータの固定値検証
+     * - 生成されるランダム値の長さ検証
+     */
+    it("Discord認証URLとセッションIDを生成し、適切な値とDBへの保存が行われること", async () => {
+      // Arrange
+      const expectedUrlParameters = {
+        client_id: MOCK_CLIENT_ID,
+        response_type: "code",
+        redirect_uri: `${MOCK_BASE_URL}/api/auth/callback`,
+        scope: "identify openid",
+        code_challenge_method: "S256"
+      };
+
+      const expectedLengths = {
+        sessionID: 32,
+        state: 32,
+        nonce: 32,
+        codeChallenge: 43 // Base64URL エンコードされたSHA-256ハッシュ
+      };
+
+      // Act
+      const result = await discordAuthInitiateUseCase.execute(mockContext);
+
+      // Assert
+      expect(result).toMatchObject({
+        authURL: expect.stringContaining(
+          "https://discord.com/oauth2/authorize"
+        ),
+        sessionID: expect.any(String)
+      });
+
+      const url = new URL(result.authURL);
+      const state = url.searchParams.get("state");
+      const nonce = url.searchParams.get("nonce");
+      const codeChallenge = url.searchParams.get("code_challenge");
+
+      Object.entries(expectedUrlParameters).forEach(
+        ([param, expectedValue]) => {
+          expect(url.searchParams.get(param)).toBe(expectedValue);
+        }
+      );
+
+      // MEMO: expectedUrlParametersで確認できていないパラメータの存在確認を含めたアサート
+      expect(result.sessionID).toHaveLength(expectedLengths.sessionID);
+      expect(state).toHaveLength(expectedLengths.state);
+      expect(nonce).toHaveLength(expectedLengths.nonce);
+      expect(codeChallenge).toHaveLength(expectedLengths.codeChallenge);
+    });
+  });
+});

--- a/packages/backend/__tests__/application/use-case/discordAuthUseCase.test.ts
+++ b/packages/backend/__tests__/application/use-case/discordAuthUseCase.test.ts
@@ -57,7 +57,6 @@ describe("DiscordAuthUseCase Tests", () => {
   beforeEach(() => {
     // モック作成
     mockDiscordOIDCService = {
-      generateAuthUrl: vi.fn(),
       exchangeCodeForTokens: vi.fn(),
       refreshTokens: vi.fn(),
       getUserResource: vi.fn(),

--- a/packages/backend/src/application/services/discord-oidc.ts
+++ b/packages/backend/src/application/services/discord-oidc.ts
@@ -308,39 +308,6 @@ export class DiscordOIDCService implements DiscordOIDCServiceInterface {
     }
   }
 
-  private generateSecureRandomString(length: number): string {
-    // Web Crypto API を優先し、フォールバックは使わない（Workers/Node18+想定）
-    const bytes = new Uint8Array(length);
-
-    // @ts-ignore
-    (globalThis.crypto || crypto).getRandomValues(bytes);
-    const base64url = (arr: Uint8Array) =>
-      btoa(String.fromCharCode(...arr))
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=+$/, "");
-    // 指定長に合わせてエンコード結果を切り出し
-    return base64url(bytes).slice(0, length);
-  }
-
-  private async generateCodeChallenge(codeVerifier: string): Promise<string> {
-    const enc = new TextEncoder();
-    const data = enc.encode(codeVerifier);
-
-    // @ts-ignore
-    const digest = await (globalThis.crypto || crypto).subtle.digest(
-      "SHA-256",
-      data
-    );
-    const bytes = new Uint8Array(digest as ArrayBuffer);
-    const base64url = (arr: Uint8Array) =>
-      btoa(String.fromCharCode(...arr))
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=+$/, "");
-    return base64url(bytes);
-  }
-
   private isDiscordIdTokenPayload(
     payload: any
   ): payload is DiscordIdTokenPayload {

--- a/packages/backend/src/application/use-case/discord-auth/DiscordAuthInitiateUseCase.ts
+++ b/packages/backend/src/application/use-case/discord-auth/DiscordAuthInitiateUseCase.ts
@@ -1,0 +1,106 @@
+import type { Context } from "hono";
+import { inject } from "inversify";
+import { TYPES } from "../../../infrastructure/config/types";
+import type { StateRepositoryInterface } from "../../../infrastructure/repositories/StateRepository";
+
+/** Discord OAuth 2.0認証エンドポイントのベースURL */
+const DISCORD_OAUTH_BASE_URL = "https://discord.com/oauth2/authorize";
+
+type DiscordAuthInitiateUseCaseResult = {
+  authURL: string;
+  sessionID: string;
+};
+
+export interface DiscordAuthInitiateUseCaseInterface {
+  execute(c: Context): Promise<DiscordAuthInitiateUseCaseResult>;
+}
+
+/**
+ * Discord OAuth 2.0 + PKCE + OpenID Connect認証を開始するユースケース
+ *
+ * このクラスは以下の処理を行います：
+ * 1. セキュアなランダム値（sessionID, state, nonce, codeVerifier）の生成
+ * 2. PKCE用のcodeChallenge生成
+ * 3. 認証状態の永続化（15分間の有効期限付き）
+ * 4. Discord認証URLの構築
+ *
+ * セキュリティ対策：
+ * - CSRF攻撃対策（state parameter）
+ * - リプレイ攻撃対策（nonce）
+ * - 認可コード横取り攻撃対策（PKCE）
+ */
+export class DiscordAuthInitiateUseCase
+  implements DiscordAuthInitiateUseCaseInterface
+{
+  constructor(
+    @inject(TYPES.StateRepository)
+    private readonly stateRepository: StateRepositoryInterface
+  ) {}
+
+  async execute(c: Context): Promise<DiscordAuthInitiateUseCaseResult> {
+    const sessionID = this.generateSecureRandomString(32);
+    const state = this.generateSecureRandomString(32);
+    const nonce = this.generateSecureRandomString(32);
+    const codeVerifier = this.generateSecureRandomString(64);
+    const codeChallenge = await this.generateCodeChallenge(codeVerifier);
+
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15分間有効
+    await this.stateRepository.save(
+      sessionID,
+      state,
+      nonce,
+      codeVerifier,
+      expiresAt
+    );
+
+    const params = new URLSearchParams();
+    params.append("client_id", c.env.DISCORD_CLIENT_ID);
+    params.append("response_type", "code");
+    params.append("redirect_uri", `${c.env.BASE_URL}/api/auth/callback`);
+    params.append("scope", "identify openid");
+    params.append("state", state);
+    params.append("nonce", nonce);
+    params.append("code_challenge", codeChallenge);
+    params.append("code_challenge_method", "S256");
+
+    const authURL = `${DISCORD_OAUTH_BASE_URL}?${params.toString()}`;
+    return { authURL, sessionID };
+  }
+
+  /** 暗号学的に安全なランダム文字列を生成する */
+  private generateSecureRandomString(length: number): string {
+    const bytes = new Uint8Array(length);
+
+    // TODO: ts-ignoreを剥がす
+    // @ts-ignore
+    (globalThis.crypto || crypto).getRandomValues(bytes);
+    const base64url = (arr: Uint8Array) =>
+      btoa(String.fromCharCode(...arr))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+    return base64url(bytes).slice(0, length);
+  }
+
+  /** PKCE用のコードチャレンジを生成する */
+  private async generateCodeChallenge(codeVerifier: string): Promise<string> {
+    const enc = new TextEncoder();
+    const data = enc.encode(codeVerifier);
+
+    // TODO: ts-ignoreを剥がす
+    // @ts-ignore
+    const digest = await (globalThis.crypto || crypto).subtle.digest(
+      "SHA-256",
+      data
+    );
+    const bytes = new Uint8Array(digest as ArrayBuffer);
+    const base64url = (arr: Uint8Array) =>
+      btoa(String.fromCharCode(...arr))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+    return base64url(bytes);
+  }
+}

--- a/packages/backend/src/infrastructure/config/types.ts
+++ b/packages/backend/src/infrastructure/config/types.ts
@@ -13,6 +13,7 @@ export const TYPES = {
 
   // Usecases
   DiscordAuthCallbackUseCase: Symbol.for("DiscordAuthCallbackUseCase"),
+  DiscordAuthInitiateUseCase: Symbol.for("DiscordAuthInitiateUseCase"),
 
   // Controllers
   AuthController: Symbol.for("AuthController")

--- a/packages/backend/src/presentation/routes/auth.ts
+++ b/packages/backend/src/presentation/routes/auth.ts
@@ -5,7 +5,7 @@ export const auth = new Hono<{ Variables: Variables }>();
 
 auth.get("/", async (c) => {
   const controller = c.get("authController");
-  return controller.RedirectToAuthUrl(c);
+  return controller.redirectToAuthURL(c);
 });
 
 auth.get("/callback", async (c) => {


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
既存の認証リダイレクトコントローラがアプリケーションのサービスモジュールに依存していたが、ユースケースに依存させたいため、リファクタリングを行った。またユースケース層のテストを書いた。

## やったこと
- `DiscordAuthInitiateUseCase`クラスの作成
  - テストの作成
- コントローラ周りのリネーム
- ユースケースを呼び出し、サービス層の依存を解消した
- generateAuthUrlメソッドを削除した

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
テストが通ること

## リリース時本番環境で確認すること
discord認証ができること
