### PR TITLE
[UseCase]DiscordTokenServiceクラスの作成

### DIFF
--- a/packages/backend/__tests__/application/services/DiscordTokenService.test.ts
+++ b/packages/backend/__tests__/application/services/DiscordTokenService.test.ts
@@ -1,0 +1,165 @@
+import type { Context } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DiscordTokenService,
+  type DiscordToken
+} from "../../../src/application/services/discord-auth/DiscordTokenService";
+import { expectErr, expectOk } from "../../testing/utils/AssertResult";
+
+describe("DiscordTokenService Tests", () => {
+  const MOCK_CLIENT_ID = "test_client_id";
+  const MOCK_CLIENT_SECRET = "test_client_secret";
+  const MOCK_BASE_URL = "https://api.test.com";
+  const MOCK_CODE = "test_authorization_code";
+  const MOCK_CODE_VERIFIER = "test_code_verifier";
+
+  const mockFetch = vi.fn();
+  vi.stubGlobal("fetch", mockFetch);
+
+  const mockContext = {
+    env: {
+      DISCORD_CLIENT_ID: MOCK_CLIENT_ID,
+      DISCORD_CLIENT_SECRET: MOCK_CLIENT_SECRET,
+      BASE_URL: MOCK_BASE_URL
+    }
+  } as Context;
+
+  const discordTokenService = new DiscordTokenService();
+
+  describe("exchangeCodeForTokens", () => {
+    /**
+     * 正常ケース：Discord認証コードの正常なトークン交換
+     *
+     * @description 有効なコードとcode_verifierでトークン交換が成功することを確認
+     *
+     * Arrange
+     * - 成功レスポンス（200 OK）をモック
+     * - 有効なトークンレスポンスを設定
+     *
+     * Act
+     * - exchangeCodeForTokensメソッドを実行
+     *
+     * Assert
+     * - トークン情報の正確性確認
+     * - 適切なAPIリクエストの実行確認
+     */
+    it("有効なコードとcode_verifierでトークン交換が成功し、正しいトークン情報が返されること", async () => {
+      // Arrange
+      const expected: DiscordToken = {
+        access_token: "mock_access_token",
+        expires_in: 3600,
+        refresh_token: "mock_refresh_token",
+        scope: "identify guilds",
+        token_type: "Bearer",
+        id_token: "mock_id_token"
+      };
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: vi.fn().mockResolvedValue(expected)
+      });
+
+      // Act
+      const result = await discordTokenService.exchangeCodeForTokens(
+        mockContext,
+        MOCK_CODE,
+        MOCK_CODE_VERIFIER
+      );
+
+      // Assert
+      expect(fetch).toHaveBeenCalledWith(
+        "https://discord.com/api/oauth2/token",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+          }
+        })
+      );
+
+      const tokenResponse = expectOk(result);
+      expect(tokenResponse).toEqual(expected);
+    });
+
+    /**
+     * エラーケース：Discord APIエラーレスポンスのテストケース
+     *
+     * @description Discord APIが4xxエラーを返した場合の適切なエラー処理
+     */
+    it("Discord APIが400エラーを返した場合はTokenExchangeFailedErrorが返されること", async () => {
+      // Arrange
+      const errorText = "invalid_grant";
+      mockFetch.mockResolvedValueOnce({
+        status: 400,
+        ok: false,
+        text: vi.fn().mockResolvedValue(errorText),
+        json: vi.fn().mockResolvedValue({ error: errorText })
+      });
+
+      // Act
+      const result = await discordTokenService.exchangeCodeForTokens(
+        mockContext,
+        MOCK_CODE,
+        MOCK_CODE_VERIFIER
+      );
+
+      // Assert
+      expect(fetch).toHaveBeenCalledWith(
+        "https://discord.com/api/oauth2/token",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+          }
+        })
+      );
+      const error = expectErr(result);
+      expect(error.name).toBe("TokenExchangeFailedError");
+      expect(error.message).toContain(
+        "Discord token exchange failed: 400 - invalid_grant"
+      );
+      expect(error.statusCode).toBe(400);
+      expect(error.responseText).toBe(errorText);
+    });
+
+    /**
+     * エラーケース：Discord APIサーバーエラーのテストケース
+     *
+     * @description Discord APIが5xxエラーを返した場合の適切なエラー処理確認
+     */
+    it("Discord APIが500エラーを返した場合はTokenExchangeFailedErrorが返されること", async () => {
+      // Arrange
+      const errorText = "Internal Server Error";
+      mockFetch.mockResolvedValueOnce({
+        status: 500,
+        ok: false,
+        text: vi.fn().mockResolvedValue(errorText),
+        json: vi.fn().mockResolvedValue({ error: errorText })
+      });
+      // Act
+      const result = await discordTokenService.exchangeCodeForTokens(
+        mockContext,
+        MOCK_CODE,
+        MOCK_CODE_VERIFIER
+      );
+
+      // Assert
+      expect(fetch).toHaveBeenCalledWith(
+        "https://discord.com/api/oauth2/token",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+          }
+        })
+      );
+      const error = expectErr(result);
+      expect(error.name).toBe("TokenExchangeFailedError");
+      expect(error.message).toContain(
+        "Discord token exchange failed: 500 - Internal Server Error"
+      );
+      expect(error.statusCode).toBe(500);
+      expect(error.responseText).toBe(errorText);
+    });
+  });
+});

--- a/packages/backend/src/application/services/discord-auth/DiscordTokenService.ts
+++ b/packages/backend/src/application/services/discord-auth/DiscordTokenService.ts
@@ -1,0 +1,124 @@
+import type { Context } from "hono";
+import { injectable } from "inversify";
+import type { Result } from "neverthrow";
+import { err, ok } from "neverthrow";
+
+/**
+ * Discord トークン交換レスポンス
+ */
+export type DiscordToken = {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+  token_type: string;
+  id_token: string;
+};
+
+/**
+ * Discord トークンサービスのインターフェース
+ */
+export interface DiscordTokenServiceInterface {
+  exchangeCodeForTokens(
+    c: Context,
+    code: string,
+    codeVerifier: string
+  ): Promise<Result<DiscordToken, ExchangeCodeForTokensError>>;
+}
+
+/**
+ * Discord トークンサービス
+ *
+ * Discord OAuth認証フローにおけるトークン関連の処理を担当する。
+ */
+@injectable()
+export class DiscordTokenService implements DiscordTokenServiceInterface {
+  /**
+   * Discord認証コードをアクセストークンに交換する
+   *
+   * 以下の処理を行う：
+   * 1. Discord OAuth2 トークンエンドポイントにリクエスト送信
+   * 2. PKCEのcode_verifierを使用した検証
+   * 3. エラー時の詳細ログ出力
+   *
+   * @param c - Honoコンテキスト（環境変数アクセス用）
+   * @param code - Discord認証コード
+   * @param codeVerifier - PKCE用のコード検証子
+   * @returns トークン交換結果（成功時はトークン情報、失敗時はエラー）
+   */
+  async exchangeCodeForTokens(
+    c: Context,
+    code: string,
+    codeVerifier: string
+  ): Promise<Result<DiscordToken, ExchangeCodeForTokensError>> {
+    const DISCORD_TOKEN_ENDPOINT = "https://discord.com/api/oauth2/token";
+
+    const params = toTokenRequestURLSearchParams({
+      clientID: c.env.DISCORD_CLIENT_ID,
+      clientSecret: c.env.DISCORD_CLIENT_SECRET,
+      code,
+      redirectURI: `${c.env.BASE_URL}/api/auth/callback`,
+      codeVerifier
+    });
+
+    const response = await fetch(DISCORD_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: params
+    });
+
+    if (!response.ok)
+      return err(
+        new TokenExchangeFailedError(response.status, await response.text())
+      );
+
+    const data = (await response.json()) as DiscordToken;
+    return ok(data);
+  }
+}
+
+/**
+ * Discord OAuth2 トークンリクエストパラメータ
+ */
+type DiscordTokenRequestParams = {
+  clientID: string;
+  clientSecret: string;
+  code: string;
+  redirectURI: string;
+  codeVerifier: string;
+};
+
+/**
+ * Discord OAuth2 トークンリクエスト用のURLSearchParamsを構築する
+ */
+const toTokenRequestURLSearchParams = (
+  params: DiscordTokenRequestParams
+): URLSearchParams => {
+  const searchParams = new URLSearchParams();
+
+  searchParams.append("client_id", params.clientID);
+  searchParams.append("client_secret", params.clientSecret);
+  searchParams.append("grant_type", "authorization_code");
+  searchParams.append("code", params.code);
+  searchParams.append("redirect_uri", params.redirectURI);
+  searchParams.append("code_verifier", params.codeVerifier);
+
+  return searchParams;
+};
+
+type ExchangeCodeForTokensError = TokenExchangeFailedError;
+
+/**
+ * Discord API呼び出しが失敗した場合のエラー
+ */
+class TokenExchangeFailedError extends Error {
+  readonly name = this.constructor.name;
+  constructor(
+    public readonly statusCode: number,
+    public readonly responseText: string
+  ) {
+    super(`Discord token exchange failed: ${statusCode} - ${responseText}`);
+  }
+}

--- a/packages/backend/src/infrastructure/config/inversify.config.ts
+++ b/packages/backend/src/infrastructure/config/inversify.config.ts
@@ -3,6 +3,8 @@ import type { DbClientInterface } from "../../../database/connection";
 import { DbClient } from "../../../database/connection";
 import type { DiscordOAuthFlowServiceInterface } from "../../application/services/discord-auth/DiscordOAuthFlowService";
 import { DiscordOAuthFlowService } from "../../application/services/discord-auth/DiscordOAuthFlowService";
+import type { DiscordTokenServiceInterface } from "../../application/services/discord-auth/DiscordTokenService";
+import { DiscordTokenService } from "../../application/services/discord-auth/DiscordTokenService";
 import type { DiscordOIDCServiceInterface } from "../../application/services/discord-oidc";
 import { DiscordOIDCService } from "../../application/services/discord-oidc";
 import type { JwtServiceInterface } from "../../application/services/jwt";
@@ -56,6 +58,10 @@ container
   .bind<DiscordOAuthFlowServiceInterface>(TYPES.DiscordOAuthFlowService)
   .to(DiscordOAuthFlowService)
   .inRequestScope();
+container
+  .bind<DiscordTokenServiceInterface>(TYPES.DiscordTokenService)
+  .to(DiscordTokenService)
+  .inSingletonScope();
 
 // Usecases
 container

--- a/packages/backend/src/infrastructure/config/types.ts
+++ b/packages/backend/src/infrastructure/config/types.ts
@@ -10,6 +10,7 @@ export const TYPES = {
   // Services
   DiscordOIDCService: Symbol.for("DiscordOIDCService"),
   DiscordOAuthFlowService: Symbol.for("DiscordOAuthFlowService"),
+  DiscordTokenService: Symbol.for("DiscordTokenService"),
   JwtService: Symbol.for("JwtService"),
 
   // Usecases


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
DiscordOIDCServiceが肥大化しているため、リファクタリングを行った。
本PRでは、Discord OAuth認証フローにおけるトークン関連の処理を担当するの検証部分を`DiscordTokenService`というサービスに切ることで可読性を上げることに努めた。

## やったこと
- `DiscordTokenService`の実装
  - テストを書いた

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
- テストが通ること
- CIが通ること

## リリース時本番環境で確認すること
本番環境において、discord認証ができること
