### PR TITLE
[UseCase]DiscordUserServiceクラスの作成

### DIFF
--- a/packages/backend/__tests__/application/services/DiscordOIDCService.test.ts
+++ b/packages/backend/__tests__/application/services/DiscordOIDCService.test.ts
@@ -11,8 +11,7 @@ import {
 import {
   DiscordOIDCService,
   type DiscordIdTokenPayload,
-  type DiscordJWK,
-  type DiscordUserResource
+  type DiscordJWK
 } from "../../../src/application/services/discord-oidc";
 import type { StateRepositoryInterface } from "../../../src/infrastructure/repositories/StateRepository";
 
@@ -38,8 +37,6 @@ const MOCK_NONCE = "test_nonce";
 const MOCK_ACCESS_TOKEN = "test_access_token";
 const MOCK_ID_TOKEN = "test_id_token";
 const MOCK_USER_ID = "123456789012345678";
-const MOCK_USERNAME = "testuser";
-const MOCK_AVATAR = "avatar_hash";
 
 // モック作成ファクトリー
 const createMocks = () => ({
@@ -117,56 +114,6 @@ describe("DiscordOIDCService Tests", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe("getUserResource", () => {
-    const mockUserResource: DiscordUserResource = {
-      id: MOCK_USER_ID,
-      username: MOCK_USERNAME,
-      avatar: MOCK_AVATAR
-    };
-
-    it("正常にユーザー情報を取得できること", async () => {
-      // Arrange
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: vi.fn().mockResolvedValue(mockUserResource)
-      });
-
-      // Act
-      const result = await service.getUserResource(
-        mocks.context,
-        MOCK_ACCESS_TOKEN
-      );
-
-      // Assert
-      expect(result).toEqual(mockUserResource);
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://discord.com/api/users/@me",
-        {
-          headers: {
-            Authorization: `Bearer ${MOCK_ACCESS_TOKEN}`
-          }
-        }
-      );
-    });
-
-    it("無効なアクセストークンの場合、例外が発生すること", async () => {
-      // Arrange
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 401,
-        statusText: "Unauthorized",
-        text: vi.fn().mockResolvedValue("Invalid access token")
-      });
-
-      // Act & Assert
-      await expect(
-        service.getUserResource(mocks.context, "invalid_token")
-      ).rejects.toThrow(
-        "Discord user resource retrieval failed: 401 Unauthorized"
-      );
-    });
   });
 
   describe("revokeAccessToken", () => {

--- a/packages/backend/__tests__/application/services/DiscordUserService.test.ts
+++ b/packages/backend/__tests__/application/services/DiscordUserService.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DiscordUserService,
+  type DiscordUserResource
+} from "../../../src/application/services/discord-auth/DiscordUserService";
+import { expectErr, expectOk } from "../../testing/utils/AssertResult";
+
+describe("DiscordUserService Tests", () => {
+  const mockFetch = vi.fn();
+  global.fetch = mockFetch;
+
+  const MOCK_ACCESS_TOKEN = "test_access_token";
+  const MOCK_USER_ID = "123456789012345678";
+  const MOCK_USERNAME = "test_user";
+  const MOCK_AVATAR = "avatar_hash";
+
+  const service = new DiscordUserService();
+
+  describe("getUserResource", () => {
+    const mockUserResource: DiscordUserResource = {
+      id: MOCK_USER_ID,
+      username: MOCK_USERNAME,
+      avatar: MOCK_AVATAR
+    };
+
+    /**
+     * 正常ケース：有効なアクセストークンでユーザー情報取得のテストケース
+     *
+     * @description 有効なアクセストークンを使用してDiscord APIからユーザー情報を取得できることを確認
+     *
+     * Arrange
+     * - fetchのモックを成功レスポンスに設定
+     * - 期待するユーザーリソースデータを準備
+     *
+     * Act
+     * - getUserResourceメソッドを実行
+     *
+     * Assert
+     * - 成功結果の返却確認
+     * - 正しいAPIエンドポイントへのリクエスト確認
+     * - 正しい認証ヘッダーの送信確認
+     * - 期待するユーザー情報の返却確認
+     */
+    it("有効なアクセストークンでユーザー情報を正常に取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(mockUserResource)
+      });
+
+      // Act
+      const result = await service.getUserResource(MOCK_ACCESS_TOKEN);
+
+      // Assert
+      const userResource = expectOk(result);
+      expect(userResource).toEqual(mockUserResource);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/users/@me",
+        {
+          headers: {
+            Authorization: `Bearer ${MOCK_ACCESS_TOKEN}`
+          }
+        }
+      );
+    });
+
+    /**
+     * エラーケース：無効なアクセストークンのテストケース
+     *
+     * @description 無効なアクセストークンの場合に適切なエラーが返されることを確認
+     *
+     * Arrange
+     * - fetchのモックを401エラーレスポンスに設定
+     *
+     * Act
+     * - getUserResourceメソッドを無効なトークンで実行
+     *
+     * Assert
+     * - エラー結果の返却確認
+     * - 適切なエラーメッセージと詳細情報の確認
+     */
+    it("無効なアクセストークンの場合、UserResourceRetrievalFailedErrorが返されること", async () => {
+      // Arrange
+      const errorStatusCode = 401;
+      const errorText = "Invalid access token";
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: errorStatusCode,
+        text: vi.fn().mockResolvedValue(errorText)
+      });
+
+      // Act
+      const result = await service.getUserResource("invalid_token");
+
+      // Assert
+      const error = expectErr(result);
+      expect(error.name).toBe("UserResourceRetrievalFailedError");
+      expect(error.message).toBe(
+        `Discord user resource retrieval failed: ${errorStatusCode} - ${errorText}`
+      );
+      expect(error.statusCode).toBe(errorStatusCode);
+      expect(error.responseText).toBe(errorText);
+    });
+
+    /**
+     * エラーケース：サーバーエラーのテストケース
+     *
+     * @description Discord APIのサーバーエラーの場合の適切なエラー処理確認
+     */
+    it("サーバーエラー（500番台）の場合、適切なエラーが返されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: vi.fn().mockResolvedValue("Internal Server Error")
+      });
+
+      // Act
+      const result = await service.getUserResource(MOCK_ACCESS_TOKEN);
+
+      // Assert
+      const error = expectErr(result);
+      expect(error.name).toBe("UserResourceRetrievalFailedError");
+      expect(error.statusCode).toBe(500);
+      expect(error.responseText).toBe("Internal Server Error");
+      expect(error.message).toContain("Discord user resource retrieval failed");
+    });
+
+    /**
+     * 境界値テスト：空文字列のアクセストークンのテストケース
+     *
+     * @description 空文字列のアクセストークンでも適切にAPIコールが行われることを確認
+     */
+    it("空文字列のアクセストークンでも適切にAPIコールが行われること", async () => {
+      // Arrange
+      const emptyToken = "";
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: vi.fn().mockResolvedValue("Unauthorized")
+      });
+
+      // Act
+      const result = await service.getUserResource(emptyToken);
+
+      // Assert
+      const error = expectErr(result);
+      expect(error.statusCode).toBe(401);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://discord.com/api/users/@me",
+        {
+          headers: {
+            Authorization: `Bearer ${""}`
+          }
+        }
+      );
+    });
+  });
+});

--- a/packages/backend/src/application/services/discord-auth/DiscordUserService.ts
+++ b/packages/backend/src/application/services/discord-auth/DiscordUserService.ts
@@ -1,0 +1,82 @@
+import { injectable } from "inversify";
+import type { Result } from "neverthrow";
+import { err, ok } from "neverthrow";
+
+/**
+ * Discordのユーザー情報
+ */
+export interface DiscordUserResource {
+  id: string;
+  username: string;
+  avatar: string;
+}
+
+/**
+ * Discord ユーザーサービスのインターフェース
+ */
+export interface DiscordUserServiceInterface {
+  getUserResource(
+    accessToken: string
+  ): Promise<Result<DiscordUserResource, GetUserResourceError>>;
+}
+
+/**
+ * Discord ユーザーサービス
+ *
+ * Discord APIからのユーザー情報取得を担当する。
+ * - アクセストークンを使用したユーザー情報の取得
+ * - APIエラーハンドリング
+ */
+@injectable()
+export class DiscordUserService implements DiscordUserServiceInterface {
+  private readonly DISCORD_USER_RESOURCE_ENDPOINT =
+    "https://discord.com/api/users/@me";
+
+  /**
+   * Discord APIからユーザー情報を取得する
+   *
+   * 以下の処理を行う：
+   * 1. Discord API `/users/@me` エンドポイントにリクエスト送信
+   * 2. アクセストークンを使用した認証
+   *
+   * @param accessToken - Discordアクセストークン
+   * @returns ユーザー情報取得結果（成功時はユーザー情報、失敗時はエラー）
+   */
+  async getUserResource(
+    accessToken: string
+  ): Promise<Result<DiscordUserResource, GetUserResourceError>> {
+    const response = await fetch(`${this.DISCORD_USER_RESOURCE_ENDPOINT}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+
+    if (!response.ok)
+      return err(
+        new UserResourceRetrievalFailedError(
+          response.status,
+          await response.text()
+        )
+      );
+
+    const data = (await response.json()) as DiscordUserResource;
+    return ok(data);
+  }
+}
+
+type GetUserResourceError = UserResourceRetrievalFailedError;
+
+/**
+ * Discord API呼び出しが失敗した場合のエラー
+ */
+class UserResourceRetrievalFailedError extends Error {
+  readonly name = this.constructor.name;
+  constructor(
+    public readonly statusCode: number,
+    public readonly responseText: string
+  ) {
+    super(
+      `Discord user resource retrieval failed: ${statusCode} - ${responseText}`
+    );
+  }
+}

--- a/packages/backend/src/application/services/discord-auth/DiscordUserService.ts
+++ b/packages/backend/src/application/services/discord-auth/DiscordUserService.ts
@@ -29,9 +29,6 @@ export interface DiscordUserServiceInterface {
  */
 @injectable()
 export class DiscordUserService implements DiscordUserServiceInterface {
-  private readonly DISCORD_USER_RESOURCE_ENDPOINT =
-    "https://discord.com/api/users/@me";
-
   /**
    * Discord APIからユーザー情報を取得する
    *
@@ -45,7 +42,9 @@ export class DiscordUserService implements DiscordUserServiceInterface {
   async getUserResource(
     accessToken: string
   ): Promise<Result<DiscordUserResource, GetUserResourceError>> {
-    const response = await fetch(`${this.DISCORD_USER_RESOURCE_ENDPOINT}`, {
+    const DISCORD_USER_RESOURCE_ENDPOINT = "https://discord.com/api/users/@me";
+
+    const response = await fetch(`${DISCORD_USER_RESOURCE_ENDPOINT}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`
       }

--- a/packages/backend/src/application/services/discord-oidc.ts
+++ b/packages/backend/src/application/services/discord-oidc.ts
@@ -3,10 +3,6 @@ import { injectable } from "inversify";
 import * as jose from "jose";
 
 export interface DiscordOIDCServiceInterface {
-  getUserResource(
-    c: Context,
-    accessToken: string
-  ): Promise<DiscordUserResource>;
   revokeAccessToken(c: Context, accessToken: string): Promise<void>;
   verifyIdToken(
     c: Context,
@@ -24,30 +20,6 @@ export class DiscordOIDCService implements DiscordOIDCServiceInterface {
   private cacheExpiry: number = 0;
   private readonly cacheLifetime = 3600000;
 
-  async getUserResource(
-    c: Context,
-    accessToken: string
-  ): Promise<DiscordUserResource> {
-    const response = await fetch(`${this.discordApiBaseUrl}/users/@me`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`
-      }
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(
-        `Discord user resource retrieval failed with status ${response.status}:`,
-        errorText
-      );
-      throw new Error(
-        `Discord user resource retrieval failed: ${response.status} ${response.statusText}`
-      );
-    }
-
-    const data = (await response.json()) as DiscordUserResource;
-    return data;
-  }
 
   async revokeAccessToken(c: Context, accessToken: string): Promise<void> {
     const params = new URLSearchParams();
@@ -214,11 +186,6 @@ export interface DiscordOIDCTokenResponse {
   id_token: string;
 }
 
-export interface DiscordUserResource {
-  id: string;
-  username: string;
-  avatar: string;
-}
 
 export interface DiscordIdTokenPayload {
   iss: string; // https://discord.com

--- a/packages/backend/src/application/use-case/discord-auth/DiscordAuthCallbackUseCase.ts
+++ b/packages/backend/src/application/use-case/discord-auth/DiscordAuthCallbackUseCase.ts
@@ -9,6 +9,7 @@ import { handleResult } from "../../../utils/ResultHelper";
 import { toAuthPayloadDTO, type AuthPayloadDTO } from "../../dtos/auth.dto";
 import type { DiscordOAuthFlowServiceInterface } from "../../services/discord-auth/DiscordOAuthFlowService";
 import type { DiscordTokenServiceInterface } from "../../services/discord-auth/DiscordTokenService";
+import type { DiscordUserServiceInterface } from "../../services/discord-auth/DiscordUserService";
 import type { DiscordOIDCServiceInterface } from "../../services/discord-oidc";
 import type { JwtServiceInterface } from "../../services/jwt";
 
@@ -30,6 +31,8 @@ export class DiscordAuthCallbackUseCase
     private readonly oauthFlowService: DiscordOAuthFlowServiceInterface,
     @inject(TYPES.DiscordTokenService)
     private readonly discordTokenService: DiscordTokenServiceInterface,
+    @inject(TYPES.DiscordUserService)
+    private readonly discordUserService: DiscordUserServiceInterface,
     @inject(TYPES.DiscordOIDCService)
     private readonly discordOIDCService: DiscordOIDCServiceInterface,
     @inject(TYPES.UserRepository)
@@ -70,9 +73,9 @@ export class DiscordAuthCallbackUseCase
       sub: idTokenPayload.sub
     });
 
-    const discordUserResource = await this.discordOIDCService.getUserResource(
-      c,
-      tokenResponse.access_token
+    const discordUserResource = handleResult(
+      await this.discordUserService.getUserResource(tokenResponse.access_token),
+      (error) => new AuthenticationUseCaseError(error)
     );
 
     if (idTokenPayload.sub !== discordUserResource.id) {

--- a/packages/backend/src/infrastructure/config/inversify.config.ts
+++ b/packages/backend/src/infrastructure/config/inversify.config.ts
@@ -5,6 +5,8 @@ import type { DiscordOAuthFlowServiceInterface } from "../../application/service
 import { DiscordOAuthFlowService } from "../../application/services/discord-auth/DiscordOAuthFlowService";
 import type { DiscordTokenServiceInterface } from "../../application/services/discord-auth/DiscordTokenService";
 import { DiscordTokenService } from "../../application/services/discord-auth/DiscordTokenService";
+import type { DiscordUserServiceInterface } from "../../application/services/discord-auth/DiscordUserService";
+import { DiscordUserService } from "../../application/services/discord-auth/DiscordUserService";
 import type { DiscordOIDCServiceInterface } from "../../application/services/discord-oidc";
 import { DiscordOIDCService } from "../../application/services/discord-oidc";
 import type { JwtServiceInterface } from "../../application/services/jwt";
@@ -61,6 +63,10 @@ container
 container
   .bind<DiscordTokenServiceInterface>(TYPES.DiscordTokenService)
   .to(DiscordTokenService)
+  .inSingletonScope();
+container
+  .bind<DiscordUserServiceInterface>(TYPES.DiscordUserService)
+  .to(DiscordUserService)
   .inSingletonScope();
 
 // Usecases

--- a/packages/backend/src/infrastructure/config/types.ts
+++ b/packages/backend/src/infrastructure/config/types.ts
@@ -11,6 +11,7 @@ export const TYPES = {
   DiscordOIDCService: Symbol.for("DiscordOIDCService"),
   DiscordOAuthFlowService: Symbol.for("DiscordOAuthFlowService"),
   DiscordTokenService: Symbol.for("DiscordTokenService"),
+  DiscordUserService: Symbol.for("DiscordUserService"),
   JwtService: Symbol.for("JwtService"),
 
   // Usecases


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
DiscordOIDCServiceが肥大化しているため、リファクタリングを行った。
本PRでは、Discord APIからのユーザー情報取得を担当する`DiscordUserService`というサービスに切ることで可読性を上げることに努めた。

## やったこと
- `DiscordUserService`の実装
  - テストを書いた

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
- テストが通ること
- CIが通ること

## リリース時本番環境で確認すること
本番環境において、discord認証ができること
