### PR TITLE
データベースのインスタンスを使いまわさず、毎回新しいインスタンスを作成するように修正する

### DIFF
--- a/packages/backend/__tests__/testing/utils/GenericTableHelper.ts
+++ b/packages/backend/__tests__/testing/utils/GenericTableHelper.ts
@@ -11,7 +11,7 @@ export const insertToDatabase = async <T extends PgTable>(
   table: T,
   data: InferInsertModel<T>
 ): Promise<void> => {
-  await db.insert(table).values(data);
+  await db().insert(table).values(data);
 };
 
 /**
@@ -21,7 +21,7 @@ export const insertToDatabase = async <T extends PgTable>(
 export const deleteFromDatabase = async <T extends PgTable>(
   table: T
 ): Promise<void> => {
-  await db.delete(table);
+  await db().delete(table);
 };
 
 /**
@@ -32,7 +32,9 @@ export const deleteFromDatabase = async <T extends PgTable>(
 export const selectFromDatabase = async <T extends PgTable>(
   table: T
 ): Promise<InferSelectModel<T>[]> => {
-  return (await db.select().from(table as PgTable)) as InferSelectModel<T>[];
+  return (await db()
+    .select()
+    .from(table as PgTable)) as InferSelectModel<T>[];
 };
 
 /**
@@ -43,7 +45,7 @@ export const selectFromDatabase = async <T extends PgTable>(
 export const selectOneFromDatabase = async <T extends PgTable>(
   table: T
 ): Promise<InferSelectModel<T> | null> => {
-  const results = (await db
+  const results = (await db()
     .select()
     .from(table as PgTable)
     .limit(1)) as InferSelectModel<T>[];

--- a/packages/backend/database/client.ts
+++ b/packages/backend/database/client.ts
@@ -4,7 +4,6 @@ import { DatabaseConnectionFactory } from "./factory";
 
 export interface DbClientInterface {
   init(c: Context): void;
-  getDb(): ReturnType<typeof DatabaseConnectionFactory.createConnection>;
 }
 
 @injectable()
@@ -12,20 +11,11 @@ export class DbClient implements DbClientInterface {
   private db: ReturnType<
     typeof DatabaseConnectionFactory.createConnection
   > | null = null;
-  private context: Context | null = null;
 
   public init(c: Context): void {
-    this.context = c;
     if (!this.db) {
       this.db = connectToDatabase(c);
     }
-  }
-
-  getDb(): ReturnType<typeof DatabaseConnectionFactory.createConnection> {
-    if (!this.db || !this.context) {
-      throw new Error("DbClient not initialized. Call init() first.");
-    }
-    return this.db;
   }
 }
 
@@ -40,8 +30,7 @@ const connectToDatabase = (c: Context) => {
 };
 
 /**
- * 環境に応じたグローバルDB接続インスタンス
+ * 環境に応じたDB接続を取得する関数
+ * リクエスト毎に新しい接続を作成してCloudflare Workersの制約を回避
  */
-export const db = DatabaseConnectionFactory.createConnection();
-
-export type DbType = typeof db;
+export const db = () => DatabaseConnectionFactory.createConnection();

--- a/packages/backend/database/config.ts
+++ b/packages/backend/database/config.ts
@@ -33,13 +33,6 @@ export class DatabaseConfig {
   }
 
   /**
-   * 本番環境かどうかを判定
-   */
-  static isProductionEnvironment(): boolean {
-    return this.getEnvVar("NODE_ENV") === "production";
-  }
-
-  /**
    * データベース設定を取得
    */
   static getDatabaseConfig(): DatabaseConnectionConfig {

--- a/packages/backend/src/infrastructure/repositories/DiscordTokensRepository.ts
+++ b/packages/backend/src/infrastructure/repositories/DiscordTokensRepository.ts
@@ -28,7 +28,7 @@ export class DiscordTokensRepository
   private async findByUserID(
     userID: UserID
   ): Promise<DiscordTokensRecord | null> {
-    const discordTokens = await db.query.discordTokens.findFirst({
+    const discordTokens = await db().query.discordTokens.findFirst({
       where: eq(discordTokensSchema.userId, userID.value.value)
     });
 
@@ -59,7 +59,7 @@ export class DiscordTokensRepository
   }
 
   async save(discordTokens: DiscordTokens): Promise<void> {
-    await db.insert(discordTokensSchema).values({
+    await db().insert(discordTokensSchema).values({
       userId: discordTokens.userId.value.value,
       accessToken: discordTokens.accessToken.value,
       refreshToken: discordTokens.refreshToken.value,

--- a/packages/backend/src/infrastructure/repositories/StateRepository.ts
+++ b/packages/backend/src/infrastructure/repositories/StateRepository.ts
@@ -30,7 +30,7 @@ export class StateRepository implements StateRepositoryInterface {
     codeVerifier: string,
     expiresAt: Date
   ): Promise<void> {
-    await db.insert(oauthStateSchema).values({
+    await db().insert(oauthStateSchema).values({
       sessionId,
       state,
       nonce,
@@ -46,7 +46,7 @@ export class StateRepository implements StateRepositoryInterface {
     codeVerifier: string;
     expiresAt: Date;
   } | null> {
-    const stateRecord = await db.query.oauthState.findFirst({
+    const stateRecord = await db().query.oauthState.findFirst({
       where: eq(oauthStateSchema.sessionId, sessionId)
     });
 
@@ -62,7 +62,7 @@ export class StateRepository implements StateRepositoryInterface {
   }
 
   async delete(sessionId: string): Promise<void> {
-    await db
+    await db()
       .delete(oauthStateSchema)
       .where(eq(oauthStateSchema.sessionId, sessionId));
   }

--- a/packages/backend/src/infrastructure/repositories/UserRepository.ts
+++ b/packages/backend/src/infrastructure/repositories/UserRepository.ts
@@ -25,7 +25,7 @@ export class UserRepository implements UserRepositoryInterface {
   private async findByDiscordID(
     discordID: DiscordID
   ): Promise<UserRecord | null> {
-    const user = await db.query.user.findFirst({
+    const user = await db().query.user.findFirst({
       where: eq(userSchema.discordId, discordID.value)
     });
 
@@ -53,14 +53,16 @@ export class UserRepository implements UserRepositoryInterface {
   }
 
   async save(user: User): Promise<void> {
-    await db.insert(userSchema).values({
-      id: user.userID.value.value,
-      discordId: user.discordID.value,
-      discordUserName: user.discordUserName,
-      discordAvatar: user.discordAvatar,
-      faculty: user.faculty?.value ?? null,
-      department: user.department?.value ?? null
-    });
+    await db()
+      .insert(userSchema)
+      .values({
+        id: user.userID.value.value,
+        discordId: user.discordID.value,
+        discordUserName: user.discordUserName,
+        discordAvatar: user.discordAvatar,
+        faculty: user.faculty?.value ?? null,
+        department: user.department?.value ?? null
+      });
   }
 }
 


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
グローバルなDB接続インスタンス（export const db = getDb()）はWorker起動時の特定のIsolateで作成されるため、後続のリクエストが別のIsolateで実行される際に「Cannot perform I/O on behalf of a different request」エラーが発生する。これはCloudflare Workersがリクエスト間でのI/Oオブジェクト共有を禁止しているためである。

## やったこと
- DatabaseConnectionFactoryでインスタンスの使い回しを停止し、毎回新しいインスタンスを作成するよう修正
  - database/client.tsのdbをグローバル変数から関数に変更（export const db = () => getDb()）
  - 全リポジトリクラス（StateRepository、UserRepository、DiscordTokensRepository）でdbの呼び出しをdb()に変更し、リクエスト毎に新しい接続を作成するよう修正

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
discordログインができること

## リリース時本番環境で確認すること
discordログインができること
