### PR TITLE
[feat][UseCase]JwtVerifyUseCaseの作成

### DIFF
--- a/packages/backend/__tests__/application/use-case/JwtVerifyUseCase.test.ts
+++ b/packages/backend/__tests__/application/use-case/JwtVerifyUseCase.test.ts
@@ -1,0 +1,90 @@
+import type { Context } from "hono";
+import { sign } from "hono/jwt";
+import { describe, expect, it } from "vitest";
+import type { AppJwtPayload } from "../../../src/application/use-case/jwt/JwtVerifyUseCase";
+import { JwtVerifyUseCase } from "../../../src/application/use-case/jwt/JwtVerifyUseCase";
+import { expectErr, expectOk } from "../../testing/utils/AssertResult";
+
+const MOCK_JWT_SECRET = "test_jwt_secret";
+
+const mockContext: Context = {
+  env: {
+    JWT_SECRET: MOCK_JWT_SECRET
+  }
+} as Context;
+
+describe("JwtVerifyUseCase Tests", () => {
+  const jwtVerifyUseCase = new JwtVerifyUseCase();
+
+  describe("execute", () => {
+    /**
+     * 正常ケース：有効なJWTトークン検証成功のテストケース
+     */
+    it("有効なJWTトークンで正常にペイロードが取得されること", async () => {
+      // Arrange
+      const MOCK_USER_ID = "123456789";
+      const MOCK_EXPIRATION_TIME = Math.floor(Date.now() / 1000) + 3600;
+      const mockToken = await sign(
+        {
+          sub: MOCK_USER_ID,
+          exp: MOCK_EXPIRATION_TIME
+        },
+        MOCK_JWT_SECRET
+      );
+
+      const expected = {
+        jwtPayload: {
+          sub: MOCK_USER_ID,
+          exp: MOCK_EXPIRATION_TIME
+        }
+      } as AppJwtPayload;
+
+      // Act
+      const result = await jwtVerifyUseCase.execute(mockContext, mockToken);
+
+      // Assert
+      const actualPayload = expectOk(result);
+      expect(actualPayload).toMatchObject(expected);
+    });
+  });
+
+  /**
+   * 異常ケース：無効なトークンでエラーが返される場合のテストケース
+   *
+   * @description 無効なトークンでエラーが返されることを確認
+   */
+  it("無効なJWTトークンの場合、JwtVerifyUseCaseErrorが返されること", async () => {
+    // Act
+    const result = await jwtVerifyUseCase.execute(mockContext, "invalid_token");
+
+    // Assert
+    const error = expectErr(result);
+    expect(error.message).toBe(
+      "JWT verification failed: invalid JWT token: invalid_token"
+    );
+  });
+
+  /**
+   * 異常ケース：期限切れJWTトークンのテストケース
+   *
+   * @description 期限切れのJWTトークンでエラーが返されることを確認
+   */
+  it("期限切れのJWTトークンの場合、JwtVerifyUseCaseErrorが返されること", async () => {
+    // Arrange - 期限切れのトークンを生成
+    const expiredToken = await sign(
+      {
+        sub: "123456789",
+        exp: Math.floor(Date.now() / 1000) - 3600 // 1時間前（期限切れ）
+      },
+      MOCK_JWT_SECRET
+    );
+
+    // Act
+    const result = await jwtVerifyUseCase.execute(mockContext, expiredToken);
+
+    // Assert
+    const error = expectErr(result);
+    expect(error.message).toContain("token");
+    expect(error.message).toContain("expired");
+  });
+});

--- a/packages/backend/src/application/services/jwt.ts
+++ b/packages/backend/src/application/services/jwt.ts
@@ -2,17 +2,11 @@ import type { Context } from "hono";
 import { sign, verify } from "hono/jwt";
 import { injectable } from "inversify";
 
-type AppJwtPayload = {
-  sub: string;
-  exp: number;
-};
-
 export interface JwtServiceInterface {
   generateTokens(
     c: Context,
     userId: string
   ): Promise<{ accessToken: string; refreshToken: string }>;
-  verify(c: Context, token: string): Promise<AppJwtPayload>;
   refreshAccessToken(
     c: Context,
     refreshToken: string
@@ -53,22 +47,16 @@ export class JwtService implements JwtServiceInterface {
     return { accessToken, refreshToken };
   }
 
-  async verify(c: Context, token: string): Promise<AppJwtPayload> {
-    const secret = this.getSecret(c);
-    const payload = await verify(token, secret);
-    return payload as AppJwtPayload;
-  }
-
   async refreshAccessToken(
     c: Context,
     refreshToken: string
   ): Promise<{ accessToken: string; refreshToken: string }> {
     const secret = this.getSecret(c);
-    
+
     // リフレッシュトークンの検証
     const payload = await verify(refreshToken, secret);
     const userId = payload.sub as string;
-    
+
     // 新しいトークンペアを生成
     const newAccessToken = await sign(
       {
@@ -77,7 +65,7 @@ export class JwtService implements JwtServiceInterface {
       },
       secret
     );
-    
+
     const newRefreshToken = await sign(
       {
         sub: userId,
@@ -85,10 +73,10 @@ export class JwtService implements JwtServiceInterface {
       },
       secret
     );
-    
-    return { 
-      accessToken: newAccessToken, 
-      refreshToken: newRefreshToken 
+
+    return {
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken
     };
   }
 }

--- a/packages/backend/src/application/use-case/jwt/JwtVerifyUseCase.ts
+++ b/packages/backend/src/application/use-case/jwt/JwtVerifyUseCase.ts
@@ -1,0 +1,40 @@
+import type { Context } from "hono";
+import { verify } from "hono/jwt";
+import { injectable } from "inversify";
+import type { JWTPayload } from "jose";
+import type { Result } from "neverthrow";
+import { err, ok } from "neverthrow";
+
+export type AppJwtPayload = {
+  jwtPayload: Pick<JWTPayload, "sub" | "exp">;
+};
+
+export interface JwtVerifyUseCaseInterface {
+  execute(
+    c: Context,
+    token: string
+  ): Promise<Result<AppJwtPayload, JwtVerifyUseCaseError>>;
+}
+
+@injectable()
+export class JwtVerifyUseCase implements JwtVerifyUseCaseInterface {
+  async execute(
+    c: Context,
+    token: string
+  ): Promise<Result<AppJwtPayload, JwtVerifyUseCaseError>> {
+    try {
+      const jwtPayload = await verify(token, c.env.JWT_SECRET);
+      return ok({ jwtPayload });
+    } catch (error) {
+      return err(new JwtVerifyUseCaseError(error as Error));
+    }
+  }
+}
+
+export class JwtVerifyUseCaseError extends Error {
+  readonly name = this.constructor.name;
+  constructor(cause: Error) {
+    super(`JWT verification failed: ${cause.message}`);
+    this.cause = cause;
+  }
+}

--- a/packages/backend/src/di-container/inversify.config.ts
+++ b/packages/backend/src/di-container/inversify.config.ts
@@ -15,6 +15,8 @@ import type { DiscordAuthCallbackUseCaseInterface } from "../application/use-cas
 import { DiscordAuthCallbackUseCase } from "../application/use-case/discord-auth/DiscordAuthCallbackUseCase";
 import type { DiscordAuthInitiateUseCaseInterface } from "../application/use-case/discord-auth/DiscordAuthInitiateUseCase";
 import { DiscordAuthInitiateUseCase } from "../application/use-case/discord-auth/DiscordAuthInitiateUseCase";
+import type { JwtVerifyUseCaseInterface } from "../application/use-case/jwt/JwtVerifyUseCase";
+import { JwtVerifyUseCase } from "../application/use-case/jwt/JwtVerifyUseCase";
 import type { DiscordTokensRepositoryInterface } from "../infrastructure/repositories/DiscordTokensRepository";
 import { DiscordTokensRepository } from "../infrastructure/repositories/DiscordTokensRepository";
 import type { StateRepositoryInterface } from "../infrastructure/repositories/StateRepository";
@@ -77,6 +79,10 @@ container
 container
   .bind<DiscordAuthInitiateUseCaseInterface>(TYPES.DiscordAuthInitiateUseCase)
   .to(DiscordAuthInitiateUseCase)
+  .inRequestScope();
+container
+  .bind<JwtVerifyUseCaseInterface>(TYPES.JwtVerifyUseCase)
+  .to(JwtVerifyUseCase)
   .inRequestScope();
 
 // Controllers

--- a/packages/backend/src/di-container/types.ts
+++ b/packages/backend/src/di-container/types.ts
@@ -17,6 +17,7 @@ export const TYPES = {
   // Usecases
   DiscordAuthCallbackUseCase: Symbol.for("DiscordAuthCallbackUseCase"),
   DiscordAuthInitiateUseCase: Symbol.for("DiscordAuthInitiateUseCase"),
+  JwtVerifyUseCase: Symbol.for("JwtVerifyUseCase"),
 
   // Controllers
   AuthController: Symbol.for("AuthController")

--- a/packages/backend/src/presentation/controllers/auth.ts
+++ b/packages/backend/src/presentation/controllers/auth.ts
@@ -4,6 +4,7 @@ import { inject, injectable } from "inversify";
 import type { JwtServiceInterface } from "../../application/services/jwt";
 import type { DiscordAuthCallbackUseCaseInterface } from "../../application/use-case/discord-auth/DiscordAuthCallbackUseCase";
 import type { DiscordAuthInitiateUseCaseInterface } from "../../application/use-case/discord-auth/DiscordAuthInitiateUseCase";
+import type { JwtVerifyUseCaseInterface } from "../../application/use-case/jwt/JwtVerifyUseCase";
 import { TYPES } from "../../di-container/types";
 
 export interface AuthControllerInterface {
@@ -25,7 +26,9 @@ export class AuthController implements AuthControllerInterface {
     @inject(TYPES.DiscordAuthCallbackUseCase)
     private readonly discordAuthCallbackUseCase: DiscordAuthCallbackUseCaseInterface,
     @inject(TYPES.JwtService)
-    private readonly jwtService: JwtServiceInterface
+    private readonly jwtService: JwtServiceInterface,
+    @inject(TYPES.JwtVerifyUseCase)
+    private readonly jwtVerifyUseCase: JwtVerifyUseCaseInterface
   ) {}
 
   async redirectToAuthURL(c: Context) {
@@ -175,16 +178,16 @@ export class AuthController implements AuthControllerInterface {
       }
 
       const token = authHeader.substring(7); // "Bearer "を除去
-      const payload = await this.jwtService.verify(c, token);
+      const payload = await this.jwtVerifyUseCase.execute(c, token);
 
-      if (!payload) {
+      if (!payload.isOk()) {
         return c.json({ error: "Invalid or expired token" }, 401);
       }
 
       return c.json({
         valid: true,
-        userId: payload.sub,
-        expiresAt: payload.exp
+        userId: payload.value.jwtPayload.sub,
+        expiresAt: payload.value.jwtPayload.exp
       });
     } catch (error) {
       console.error("Token verification error:", error);


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
services/jwt.tsに集約された関数たちがコントローラ等で呼ばれており、一貫性に欠けるのとAI駆動に開発していく上で先に潰しておきたいのでリファクタを実施した

## やったこと
-` jwtService.verify`を`jwtVerifyUseCase.execute`に切り出した


## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
なし

## リリース時本番環境で確認すること
なし