### PR TITLE
[refactor]レスポンスの型をzod schema経由からプリミティブな定義に修正する

### DIFF
--- a/packages/backend/src/application/services/jwt/jwt.ts
+++ b/packages/backend/src/application/services/jwt/jwt.ts
@@ -1,7 +1,4 @@
-import {
-  toRefreshTokenResponse,
-  type RefreshTokenResponse
-} from "@pichikoto/http-contracts";
+import { type RefreshTokenResponse } from "@pichikoto/http-contracts";
 import type { Context } from "hono";
 import { sign, verify } from "hono/jwt";
 import { injectable } from "inversify";
@@ -78,6 +75,9 @@ export class JwtService implements JwtServiceInterface {
       secret
     );
 
-    return toRefreshTokenResponse(newAccessToken, newRefreshToken);
+    return {
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken
+    };
   }
 }

--- a/packages/backend/src/application/use-case/discord-auth/DiscordAuthCallbackUseCase.ts
+++ b/packages/backend/src/application/use-case/discord-auth/DiscordAuthCallbackUseCase.ts
@@ -1,5 +1,4 @@
 import type { CallbackResponse } from "@pichikoto/http-contracts";
-import { toCallbackResponse } from "@pichikoto/http-contracts";
 import type { Context } from "hono";
 import { inject, injectable } from "inversify";
 import { TYPES } from "../../../di-container/types";
@@ -97,7 +96,7 @@ export class DiscordAuthCallbackUseCase
 
       const { accessToken, refreshToken } =
         await this.jwtService.generateTokens(c, existsUser.userID.value.value);
-      return toCallbackResponse(accessToken, refreshToken);
+      return { accessToken, refreshToken };
     }
 
     const user = User.create(
@@ -122,7 +121,7 @@ export class DiscordAuthCallbackUseCase
       user.userID.value.value
     );
 
-    return toCallbackResponse(accessToken, refreshToken);
+    return { accessToken, refreshToken };
   }
 }
 

--- a/packages/http-contracts/src/auth/response.ts
+++ b/packages/http-contracts/src/auth/response.ts
@@ -1,45 +1,13 @@
-import { z } from "zod";
+export type VerifyTokenResponse = {
+  
+}
 
-export const callbackResponseSchema = z.object({
-  accessToken: z.string(),
-  refreshToken: z.string()
-});
+export type CallbackResponse = {
+  accessToken: string;
+  refreshToken: string;
+}
 
-export type CallbackResponse = z.infer<typeof callbackResponseSchema>;
-
-export const toCallbackResponse = (
-  accessToken: string,
-  refreshToken: string
-): CallbackResponse => {
-  return callbackResponseSchema.parse({
-    accessToken,
-    refreshToken
-  });
-};
-
-export const refreshTokenResponseSchema = z.object({
-  accessToken: z.string(),
-  refreshToken: z.string()
-});
-
-export type RefreshTokenResponse = z.infer<typeof refreshTokenResponseSchema>;
-
-export const toRefreshTokenResponse = (
-  accessToken: string,
-  refreshToken: string
-): RefreshTokenResponse => {
-  return refreshTokenResponseSchema.parse({
-    accessToken,
-    refreshToken
-  });
-};
-
-export const verifyTokenResponseSchema = z.object({
-  message: z.string()
-});
-
-export type VerifyTokenResponse = z.infer<typeof verifyTokenResponseSchema>;
-
-export const toVerifyTokenResponse = (message: string): VerifyTokenResponse => {
-  return verifyTokenResponseSchema.parse({ message });
-};
+export type RefreshTokenResponse = {
+  accessToken: string;
+  refreshToken: string;
+}

--- a/packages/http-contracts/src/auth/response.ts
+++ b/packages/http-contracts/src/auth/response.ts
@@ -1,5 +1,5 @@
 export type VerifyTokenResponse = {
-  
+  message: string;
 }
 
 export type CallbackResponse = {


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
レスポンス型はzodでschema定義→型生成しているメリットがない

## やったこと
- プリミティブな値で型を作成する

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
なし

## リリース時本番環境で確認すること
なし
