### PR TITLE
feat: CreateAppreciationUseCaseを実行するコントローラとルートを追加

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,6 +8,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import "reflect-metadata";
 import z from "zod";
+import { appreciation } from "./presentation/routes/appreciation";
 import { auth } from "./presentation/routes/auth";
 
 export type Env = {
@@ -58,6 +59,7 @@ app.onError((err, c) => {
   return createJsonResponse(internal.status, internal.message);
 });
 
+app.route("/appreciations", appreciation);
 app.route("/auth", auth);
 
 export default app;

--- a/packages/backend/src/presentation/controllers/appreciation.ts
+++ b/packages/backend/src/presentation/controllers/appreciation.ts
@@ -1,0 +1,54 @@
+import { toCreateAppreciationRequest } from "@pichikoto/http-contracts/appreciation";
+import type { Context } from "hono";
+import type { CreateAppreciationUseCaseInterface } from "../../application/use-case/appreciation/CreateAppreciationUseCase";
+import {
+  AppreciationMessage,
+  PointPerReceiver,
+  ReceiverIDs
+} from "../../domain/appreciation/Appreciation";
+import { UserID } from "../../domain/user/User";
+
+export interface AppreciationControllerInterface {
+  createAppreciation(c: Context): Promise<Response>;
+}
+
+export class AppreciationController implements AppreciationControllerInterface {
+  constructor(
+    private readonly createAppreciationUseCase: CreateAppreciationUseCaseInterface
+  ) {}
+
+  async createAppreciation(c: Context): Promise<Response> {
+    try {
+      const req = await toCreateAppreciationRequest(c.req.raw);
+      
+      // JWTから送信者IDを取得（認証ミドルウェアで設定されることを想定）
+      const senderID = c.get("userID");
+      if (!senderID) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const receiverIDs = ReceiverIDs.from(
+        req.body.receiverIDs.map((id: string) => UserID.from(id))
+      );
+      const message = AppreciationMessage.from(req.body.message);
+      const pointPerReceiver = PointPerReceiver.from(req.body.pointPerReceiver);
+
+      const result = await this.createAppreciationUseCase.execute(
+        UserID.from(senderID),
+        receiverIDs,
+        message,
+        pointPerReceiver
+      );
+
+      if (result.isErr()) {
+        console.error("CreateAppreciationUseCase error:", result.error);
+        return c.json({ error: "Failed to create appreciation" }, 500);
+      }
+
+      return c.json({ message: "Appreciation created successfully" }, 201);
+    } catch (error) {
+      console.error("AppreciationController error:", error);
+      return c.json({ error: "Internal server error" }, 500);
+    }
+  }
+}

--- a/packages/backend/src/presentation/routes/appreciation.ts
+++ b/packages/backend/src/presentation/routes/appreciation.ts
@@ -1,0 +1,35 @@
+import type { Context } from "hono";
+import { Hono } from "hono";
+import type { Env } from "../../index";
+import { DbClient } from "../../../database/client";
+import { CreateAppreciationUseCase } from "../../application/use-case/appreciation/CreateAppreciationUseCase";
+import { WeeklyPointLimitDomainService } from "../../domain/appreciation/WeeklyPointLimitDomainService";
+import { AppreciationRepository } from "../../infrastructure/repositories/AppreciationRepository";
+import { ConsumedPointLogRepository } from "../../infrastructure/repositories/ConsumedPointLogRepository";
+import { AppreciationController } from "../controllers/appreciation";
+
+const appreciationControllerFactory = (c: Context) => {
+  const dbClient = new DbClient();
+  dbClient.init(c);
+
+  const appreciationRepository = new AppreciationRepository();
+  const consumedPointLogRepository = new ConsumedPointLogRepository();
+  const weeklyPointLimitDomainService = new WeeklyPointLimitDomainService(
+    consumedPointLogRepository
+  );
+
+  const createAppreciationUseCase = new CreateAppreciationUseCase(
+    appreciationRepository,
+    consumedPointLogRepository,
+    weeklyPointLimitDomainService
+  );
+
+  return new AppreciationController(createAppreciationUseCase);
+};
+
+export const appreciation = new Hono<{ Bindings: Env }>();
+
+appreciation.post("/", async (c: Context) => {
+  const controller = appreciationControllerFactory(c);
+  return controller.createAppreciation(c);
+});

--- a/packages/http-contracts/package.json
+++ b/packages/http-contracts/package.json
@@ -8,6 +8,10 @@
       "types": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./appreciation": {
+      "types": "./src/appreciation/index.ts",
+      "default": "./src/appreciation/index.ts"
+    },
     "./auth": {
       "types": "./src/auth/index.ts",
       "default": "./src/auth/index.ts"

--- a/packages/http-contracts/src/appreciation/index.ts
+++ b/packages/http-contracts/src/appreciation/index.ts
@@ -1,0 +1,2 @@
+export * from "./request";
+export * from "./response";

--- a/packages/http-contracts/src/appreciation/request.ts
+++ b/packages/http-contracts/src/appreciation/request.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import {
+  createRequestParser,
+  requestSchemaWithAuth,
+  toRequestWithAuth
+} from "../utils/request";
+
+export const createAppreciationRequestSchema = requestSchemaWithAuth.extend({
+  body: z.object({
+    receiverIDs: z.array(z.string()).min(1, "At least one receiver is required"),
+    message: z.string().min(1, "Message is required"),
+    pointPerReceiver: z.number().int().min(1).max(100)
+  })
+});
+
+export type CreateAppreciationRequest = z.infer<
+  typeof createAppreciationRequestSchema
+>;
+
+export const toCreateAppreciationRequest = async (
+  req: Request
+): Promise<CreateAppreciationRequest> =>
+  createRequestParser(createAppreciationRequestSchema, toRequestWithAuth)(req);

--- a/packages/http-contracts/src/appreciation/response.ts
+++ b/packages/http-contracts/src/appreciation/response.ts
@@ -1,0 +1,3 @@
+export type CreateAppreciationResponse = {
+  message: string;
+};

--- a/packages/http-contracts/src/index.ts
+++ b/packages/http-contracts/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./appreciation";
 export * from "./auth";
 export * from "./utils";


### PR DESCRIPTION
- HTTP contracts (appreciation) を追加
- AppreciationController を作成し CreateAppreciationUseCase を実行
- api/appreciations エンドポイントでPOSTリクエストを受け付け
- 認証済みユーザーが感謝を作成できる機能を実装

## 変更領域
フロントエンドもしくはバックエンド、または両方を明記してください。

## 背景
なぜこのPRが発生したか・この変更が必要なのかを明記してください

## やったこと
箇条書きでやったことを明記してください

## 動作確認動画(スクリーンショット)
なしであればなしと明記してください

## 確認したこと(デグレチェック)
既存機能に影響がないことを確認した旨を明記してください

## リリース時本番環境で確認すること
リリース前後で確認すべきことを明記してください
