### PR TITLE
refactor: データベーステストアサーションの可読性向上

### DIFF
--- a/packages/backend/__tests__/application/services/DiscordOAuthFlowService.test.ts
+++ b/packages/backend/__tests__/application/services/DiscordOAuthFlowService.test.ts
@@ -7,10 +7,10 @@ import {
   createOauthStateTableFixtureWithExpired
 } from "../../testing/table_fixture/OauthStateTableFixture";
 import { expectErr, expectOk } from "../../testing/utils/AssertResult";
+import { getTypedSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 describe("DiscordOAuthFlowService Tests", () => {
@@ -157,10 +157,6 @@ describe("DiscordOAuthFlowService Tests", () => {
 /**
  * OAuthStateテーブルからレコードを取得するヘルパー関数
  */
-const getOauthStateRecord = async (): Promise<
-  typeof schema.oauthState.$inferSelect | null
-> => {
-  return (await selectOneFromDatabase(
-    schema.oauthState
-  )) as typeof schema.oauthState.$inferSelect;
+const getOauthStateRecord = async () => {
+  return await getTypedSingleRecord(schema.oauthState);
 };

--- a/packages/backend/__tests__/application/use-case/CreateAppreciationUseCase.test.ts
+++ b/packages/backend/__tests__/application/use-case/CreateAppreciationUseCase.test.ts
@@ -34,8 +34,8 @@ import {
 import { assertEqualConsumedPointLogTable } from "../../testing/table_assert/AssertEqualConsumedPointLogTable";
 import { expectOk } from "../../testing/utils/AssertResult";
 import {
-  assertMultipleRecords,
-  assertSingleRecord
+  getTypedMultipleRecords,
+  getTypedSingleRecord
 } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
@@ -195,23 +195,14 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      await assertSingleRecord(
-        schema.appreciations,
-        assertEqualAppreciationTable,
-        appreciation
-      );
+      const appreciationRecord = await getTypedSingleRecord(schema.appreciations);
+      assertEqualAppreciationTable(appreciation, appreciationRecord!);
 
-      await assertMultipleRecords(
-        schema.appreciationReceivers,
-        assertEqualAppreciationReceiversTable,
-        appreciation
-      );
+      const actualReceiverRecords = await getTypedMultipleRecords(schema.appreciationReceivers);
+      assertEqualAppreciationReceiversTable(appreciation, actualReceiverRecords);
 
-      await assertSingleRecord(
-        schema.consumedPointLog,
-        assertEqualConsumedPointLogTable,
-        consumedPointLog
-      );
+      const consumedPointLogRecord = await getTypedSingleRecord(schema.consumedPointLog);
+      assertEqualConsumedPointLogTable(consumedPointLog, consumedPointLogRecord!);
     });
 
     /**
@@ -408,23 +399,14 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      await assertSingleRecord(
-        schema.appreciations,
-        assertEqualAppreciationTable,
-        appreciation
-      );
+      const appreciationRecord = await getTypedSingleRecord(schema.appreciations);
+      assertEqualAppreciationTable(appreciation, appreciationRecord!);
 
-      await assertMultipleRecords(
-        schema.appreciationReceivers,
-        assertEqualAppreciationReceiversTable,
-        appreciation
-      );
+      const actualReceiverRecords = await getTypedMultipleRecords(schema.appreciationReceivers);
+      assertEqualAppreciationReceiversTable(appreciation, actualReceiverRecords);
 
-      await assertSingleRecord(
-        schema.consumedPointLog,
-        assertEqualConsumedPointLogTable,
-        consumedPointLog
-      );
+      const consumedPointLogRecord = await getTypedSingleRecord(schema.consumedPointLog);
+      assertEqualConsumedPointLogTable(consumedPointLog, consumedPointLogRecord!);
     });
   });
 });

--- a/packages/backend/__tests__/application/use-case/CreateAppreciationUseCase.test.ts
+++ b/packages/backend/__tests__/application/use-case/CreateAppreciationUseCase.test.ts
@@ -195,14 +195,26 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      const appreciationRecord = await getTypedSingleRecord(schema.appreciations);
+      const appreciationRecord = await getTypedSingleRecord(
+        schema.appreciations
+      );
       assertEqualAppreciationTable(appreciation, appreciationRecord!);
 
-      const actualReceiverRecords = await getTypedMultipleRecords(schema.appreciationReceivers);
-      assertEqualAppreciationReceiversTable(appreciation, actualReceiverRecords);
+      const actualReceiverRecords = await getTypedMultipleRecords(
+        schema.appreciationReceivers
+      );
+      assertEqualAppreciationReceiversTable(
+        appreciation,
+        actualReceiverRecords
+      );
 
-      const consumedPointLogRecord = await getTypedSingleRecord(schema.consumedPointLog);
-      assertEqualConsumedPointLogTable(consumedPointLog, consumedPointLogRecord!);
+      const consumedPointLogRecord = await getTypedSingleRecord(
+        schema.consumedPointLog
+      );
+      assertEqualConsumedPointLogTable(
+        consumedPointLog,
+        consumedPointLogRecord!
+      );
     });
 
     /**
@@ -293,6 +305,24 @@ describe("CreateAppreciationUseCase Tests", () => {
       ]);
       const highPointPerReceiver = PointPerReceiver.from(50);
 
+      const appreciation = Appreciation.reconstruct(
+        AppreciationID.new(),
+        senderID,
+        singleReceiverIDs,
+        message,
+        highPointPerReceiver,
+        CreatedAt.new()
+      );
+
+      const consumedPointLog = ConsumedPointLog.reconstruct(
+        ConsumedPointLogID.new(),
+        senderID,
+        appreciation.appreciationID,
+        WeekStartDate.new(),
+        ConsumedPoints.from(highPointPerReceiver.value),
+        CreatedAt.new()
+      );
+
       // Act
       const result = await createAppreciationUseCase.execute(
         senderID,
@@ -304,38 +334,26 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      const appreciationRecord = await selectOneFromDatabase(
+      const appreciationRecord = await getTypedSingleRecord(
         schema.appreciations
       );
-      expect(appreciationRecord).not.toBeNull();
-      expect(appreciationRecord!.senderId).toBe(senderID.value.value);
-      expect(appreciationRecord!.message).toBe(message.value);
-      expect(appreciationRecord!.pointPerReceiver).toBe(
-        highPointPerReceiver.value
-      );
+      assertEqualAppreciationTable(appreciation, appreciationRecord!);
 
-      // 2. appreciation_receiversテーブルのレコード確認（単一受信者）
-      const actualReceiverRecords = await selectFromDatabase(
+      const actualReceiverRecords = await getTypedMultipleRecords(
         schema.appreciationReceivers
       );
-      expect(actualReceiverRecords).toHaveLength(1);
-      expect(actualReceiverRecords[0].receiverId).toBe(MOCK_RECEIVER_ID_1);
-      expect(actualReceiverRecords[0].appreciationId).toBe(
-        appreciationRecord!.id
+      assertEqualAppreciationReceiversTable(
+        appreciation,
+        actualReceiverRecords
       );
 
-      // 3. consumed_point_logテーブルのレコード確認
-      const consumedPointLogRecord = await selectOneFromDatabase(
+      const consumedPointLogRecord = await getTypedSingleRecord(
         schema.consumedPointLog
       );
-      expect(consumedPointLogRecord).not.toBeNull();
-      expect(consumedPointLogRecord!.userId).toBe(senderID.value.value);
-      expect(consumedPointLogRecord!.appreciationId).toBe(
-        appreciationRecord!.id
+      assertEqualConsumedPointLogTable(
+        consumedPointLog,
+        consumedPointLogRecord!
       );
-      expect(consumedPointLogRecord!.consumedPoints).toBe(
-        highPointPerReceiver.value * 1
-      ); // 1人分
     });
 
     /**
@@ -399,14 +417,26 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      const appreciationRecord = await getTypedSingleRecord(schema.appreciations);
+      const appreciationRecord = await getTypedSingleRecord(
+        schema.appreciations
+      );
       assertEqualAppreciationTable(appreciation, appreciationRecord!);
 
-      const actualReceiverRecords = await getTypedMultipleRecords(schema.appreciationReceivers);
-      assertEqualAppreciationReceiversTable(appreciation, actualReceiverRecords);
+      const actualReceiverRecords = await getTypedMultipleRecords(
+        schema.appreciationReceivers
+      );
+      assertEqualAppreciationReceiversTable(
+        appreciation,
+        actualReceiverRecords
+      );
 
-      const consumedPointLogRecord = await getTypedSingleRecord(schema.consumedPointLog);
-      assertEqualConsumedPointLogTable(consumedPointLog, consumedPointLogRecord!);
+      const consumedPointLogRecord = await getTypedSingleRecord(
+        schema.consumedPointLog
+      );
+      assertEqualConsumedPointLogTable(
+        consumedPointLog,
+        consumedPointLogRecord!
+      );
     });
   });
 });

--- a/packages/backend/__tests__/application/use-case/CreateAppreciationUseCase.test.ts
+++ b/packages/backend/__tests__/application/use-case/CreateAppreciationUseCase.test.ts
@@ -34,10 +34,12 @@ import {
 import { assertEqualConsumedPointLogTable } from "../../testing/table_assert/AssertEqualConsumedPointLogTable";
 import { expectOk } from "../../testing/utils/AssertResult";
 import {
+  assertMultipleRecords,
+  assertSingleRecord
+} from "../../testing/utils/DatabaseAssertHelpers";
+import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectFromDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 // モック定数（有効なUUID形式）
@@ -193,25 +195,22 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      const appreciationRecord = (await selectOneFromDatabase(
-        schema.appreciations
-      )) as typeof schema.appreciations.$inferSelect;
-      assertEqualAppreciationTable(appreciation, appreciationRecord!);
-
-      const actualReceiverRecords = (await selectFromDatabase(
-        schema.appreciationReceivers
-      )) as (typeof schema.appreciationReceivers.$inferSelect)[];
-      assertEqualAppreciationReceiversTable(
-        appreciation,
-        actualReceiverRecords
+      await assertSingleRecord(
+        schema.appreciations,
+        assertEqualAppreciationTable,
+        appreciation
       );
 
-      const consumedPointLogRecord = (await selectOneFromDatabase(
-        schema.consumedPointLog
-      )) as typeof schema.consumedPointLog.$inferSelect;
-      assertEqualConsumedPointLogTable(
-        consumedPointLog,
-        consumedPointLogRecord
+      await assertMultipleRecords(
+        schema.appreciationReceivers,
+        assertEqualAppreciationReceiversTable,
+        appreciation
+      );
+
+      await assertSingleRecord(
+        schema.consumedPointLog,
+        assertEqualConsumedPointLogTable,
+        consumedPointLog
       );
     });
 
@@ -409,25 +408,22 @@ describe("CreateAppreciationUseCase Tests", () => {
       // Assert
       expectOk(result);
 
-      const appreciationRecord = (await selectOneFromDatabase(
-        schema.appreciations
-      )) as typeof schema.appreciations.$inferSelect;
-      assertEqualAppreciationTable(appreciation, appreciationRecord!);
-
-      const actualReceiverRecords = (await selectFromDatabase(
-        schema.appreciationReceivers
-      )) as (typeof schema.appreciationReceivers.$inferSelect)[];
-      assertEqualAppreciationReceiversTable(
-        appreciation,
-        actualReceiverRecords
+      await assertSingleRecord(
+        schema.appreciations,
+        assertEqualAppreciationTable,
+        appreciation
       );
 
-      const consumedPointLogRecord = (await selectOneFromDatabase(
-        schema.consumedPointLog
-      )) as typeof schema.consumedPointLog.$inferSelect;
-      assertEqualConsumedPointLogTable(
-        consumedPointLog,
-        consumedPointLogRecord
+      await assertMultipleRecords(
+        schema.appreciationReceivers,
+        assertEqualAppreciationReceiversTable,
+        appreciation
+      );
+
+      await assertSingleRecord(
+        schema.consumedPointLog,
+        assertEqualConsumedPointLogTable,
+        consumedPointLog
       );
     });
   });

--- a/packages/backend/__tests__/infrastructure/repository/AppreciationRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/AppreciationRepository.test.ts
@@ -21,10 +21,12 @@ import {
 } from "../../testing/table_fixture/AppreciationTableFixture";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
 import {
+  assertMultipleRecords,
+  assertSingleRecord
+} from "../../testing/utils/DatabaseAssertHelpers";
+import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectFromDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 describe("AppreciationRepository Tests", () => {
@@ -57,17 +59,16 @@ describe("AppreciationRepository Tests", () => {
       await appreciationRepository.store(appreciation);
 
       // assert
-      const actualAppreciationRecord = (await selectOneFromDatabase(
-        schema.appreciations
-      )) as typeof schema.appreciations.$inferSelect;
-      assertEqualAppreciationTable(appreciation, actualAppreciationRecord);
+      await assertSingleRecord(
+        schema.appreciations,
+        assertEqualAppreciationTable,
+        appreciation
+      );
 
-      const actualReceiverRecords = (await selectFromDatabase(
-        schema.appreciationReceivers
-      )) as (typeof schema.appreciationReceivers.$inferSelect)[];
-      assertEqualAppreciationReceiversTable(
-        appreciation,
-        actualReceiverRecords
+      await assertMultipleRecords(
+        schema.appreciationReceivers,
+        assertEqualAppreciationReceiversTable,
+        appreciation
       );
     });
 
@@ -100,18 +101,19 @@ describe("AppreciationRepository Tests", () => {
       await appreciationRepository.store(appreciation);
 
       // assert
-      const actualAppreciationRecord = (await selectOneFromDatabase(
-        schema.appreciations
-      )) as typeof schema.appreciations.$inferSelect;
-      assertEqualAppreciationTable(appreciation, actualAppreciationRecord);
+      await assertSingleRecord(
+        schema.appreciations,
+        assertEqualAppreciationTable,
+        appreciation
+      );
 
-      const actualReceiverRecords = (await selectFromDatabase(
-        schema.appreciationReceivers
-      )) as (typeof schema.appreciationReceivers.$inferSelect)[];
-      expect(actualReceiverRecords).toHaveLength(3);
-      assertEqualAppreciationReceiversTable(
-        appreciation,
-        actualReceiverRecords
+      await assertMultipleRecords(
+        schema.appreciationReceivers,
+        (expected, actual) => {
+          expect(actual).toHaveLength(3);
+          assertEqualAppreciationReceiversTable(expected, actual);
+        },
+        appreciation
       );
     });
   });

--- a/packages/backend/__tests__/infrastructure/repository/AppreciationRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/AppreciationRepository.test.ts
@@ -21,8 +21,8 @@ import {
 } from "../../testing/table_fixture/AppreciationTableFixture";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
 import {
-  assertMultipleRecords,
-  assertSingleRecord
+  getTypedMultipleRecords,
+  getTypedSingleRecord
 } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
@@ -59,17 +59,11 @@ describe("AppreciationRepository Tests", () => {
       await appreciationRepository.store(appreciation);
 
       // assert
-      await assertSingleRecord(
-        schema.appreciations,
-        assertEqualAppreciationTable,
-        appreciation
-      );
+      const actualAppreciationRecord = await getTypedSingleRecord(schema.appreciations);
+      assertEqualAppreciationTable(appreciation, actualAppreciationRecord!);
 
-      await assertMultipleRecords(
-        schema.appreciationReceivers,
-        assertEqualAppreciationReceiversTable,
-        appreciation
-      );
+      const actualReceiverRecords = await getTypedMultipleRecords(schema.appreciationReceivers);
+      assertEqualAppreciationReceiversTable(appreciation, actualReceiverRecords);
     });
 
     it("感謝を保存できること（複数受信者）", async () => {
@@ -101,20 +95,12 @@ describe("AppreciationRepository Tests", () => {
       await appreciationRepository.store(appreciation);
 
       // assert
-      await assertSingleRecord(
-        schema.appreciations,
-        assertEqualAppreciationTable,
-        appreciation
-      );
+      const actualAppreciationRecord = await getTypedSingleRecord(schema.appreciations);
+      assertEqualAppreciationTable(appreciation, actualAppreciationRecord!);
 
-      await assertMultipleRecords(
-        schema.appreciationReceivers,
-        (expected, actual) => {
-          expect(actual).toHaveLength(3);
-          assertEqualAppreciationReceiversTable(expected, actual);
-        },
-        appreciation
-      );
+      const actualReceiverRecords = await getTypedMultipleRecords(schema.appreciationReceivers);
+      expect(actualReceiverRecords).toHaveLength(3);
+      assertEqualAppreciationReceiversTable(appreciation, actualReceiverRecords);
     });
   });
 

--- a/packages/backend/__tests__/infrastructure/repository/ConsumedPointLogRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/ConsumedPointLogRepository.test.ts
@@ -15,10 +15,10 @@ import { assertEqualConsumedPointLogTable } from "../../testing/table_assert/Ass
 import { createAppreciationTableFixture } from "../../testing/table_fixture/AppreciationTableFixture";
 import { createConsumedPointLogTableFixtureWith } from "../../testing/table_fixture/ConsumedPointLogTableFixture";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
+import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 describe("ConsumedPointLogRepository Tests", () => {
@@ -53,10 +53,11 @@ describe("ConsumedPointLogRepository Tests", () => {
       await consumedPointLogRepository.store(consumedPointLog);
 
       // assert
-      const actualRecord = (await selectOneFromDatabase(
-        schema.consumedPointLog
-      )) as typeof schema.consumedPointLog.$inferSelect;
-      assertEqualConsumedPointLogTable(consumedPointLog, actualRecord);
+      await assertSingleRecord(
+        schema.consumedPointLog,
+        assertEqualConsumedPointLogTable,
+        consumedPointLog
+      );
     });
   });
 

--- a/packages/backend/__tests__/infrastructure/repository/ConsumedPointLogRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/ConsumedPointLogRepository.test.ts
@@ -15,7 +15,7 @@ import { assertEqualConsumedPointLogTable } from "../../testing/table_assert/Ass
 import { createAppreciationTableFixture } from "../../testing/table_fixture/AppreciationTableFixture";
 import { createConsumedPointLogTableFixtureWith } from "../../testing/table_fixture/ConsumedPointLogTableFixture";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
-import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
+import { getTypedSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
   insertToDatabase
@@ -53,11 +53,8 @@ describe("ConsumedPointLogRepository Tests", () => {
       await consumedPointLogRepository.store(consumedPointLog);
 
       // assert
-      await assertSingleRecord(
-        schema.consumedPointLog,
-        assertEqualConsumedPointLogTable,
-        consumedPointLog
-      );
+      const actualRecord = await getTypedSingleRecord(schema.consumedPointLog);
+      assertEqualConsumedPointLogTable(consumedPointLog, actualRecord!);
     });
   });
 

--- a/packages/backend/__tests__/infrastructure/repository/DiscordTokensRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/DiscordTokensRepository.test.ts
@@ -14,7 +14,7 @@ import {
   createExpiredDiscordTokensTableFixture
 } from "../../testing/table_fixture/DiscordTokensTableFixture";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
-import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
+import { getTypedSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
   insertToDatabase
@@ -122,11 +122,8 @@ describe("DiscordTokensRepository Tests", () => {
       await discordTokensRepository.save(discordTokens);
 
       // assert
-      await assertSingleRecord(
-        schema.discordTokens,
-        assertEqualDiscordTokensTable,
-        discordTokens
-      );
+      const actualRecord = await getTypedSingleRecord(schema.discordTokens);
+      assertEqualDiscordTokensTable(discordTokens, actualRecord!);
     });
   });
 });

--- a/packages/backend/__tests__/infrastructure/repository/DiscordTokensRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/DiscordTokensRepository.test.ts
@@ -14,10 +14,10 @@ import {
   createExpiredDiscordTokensTableFixture
 } from "../../testing/table_fixture/DiscordTokensTableFixture";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
+import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 describe("DiscordTokensRepository Tests", () => {
@@ -122,10 +122,11 @@ describe("DiscordTokensRepository Tests", () => {
       await discordTokensRepository.save(discordTokens);
 
       // assert
-      const actualRecord = (await selectOneFromDatabase(
-        schema.discordTokens
-      )) as typeof schema.discordTokens.$inferSelect;
-      assertEqualDiscordTokensTable(discordTokens, actualRecord);
+      await assertSingleRecord(
+        schema.discordTokens,
+        assertEqualDiscordTokensTable,
+        discordTokens
+      );
     });
   });
 });

--- a/packages/backend/__tests__/infrastructure/repository/StateRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/StateRepository.test.ts
@@ -3,10 +3,10 @@ import * as schema from "../../../database/schema";
 import { StateRepository } from "../../../src/infrastructure/repositories/StateRepository";
 import { assertEqualOauthStateTable } from "../../testing/table_assert/AssertEqualOauthStateTable";
 import { createOauthStateTableFixture } from "../../testing/table_fixture/OauthStateTableFixture";
+import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 describe("StateRepository Tests", () => {
@@ -38,10 +38,11 @@ describe("StateRepository Tests", () => {
       );
 
       // assert
-      const actualRecord = (await selectOneFromDatabase(
-        schema.oauthState
-      )) as typeof schema.oauthState.$inferSelect;
-      assertEqualOauthStateTable(expectedState, actualRecord);
+      await assertSingleRecord(
+        schema.oauthState,
+        assertEqualOauthStateTable,
+        expectedState
+      );
     });
   });
 

--- a/packages/backend/__tests__/infrastructure/repository/StateRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/StateRepository.test.ts
@@ -3,7 +3,7 @@ import * as schema from "../../../database/schema";
 import { StateRepository } from "../../../src/infrastructure/repositories/StateRepository";
 import { assertEqualOauthStateTable } from "../../testing/table_assert/AssertEqualOauthStateTable";
 import { createOauthStateTableFixture } from "../../testing/table_fixture/OauthStateTableFixture";
-import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
+import { getTypedSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
   insertToDatabase
@@ -38,11 +38,8 @@ describe("StateRepository Tests", () => {
       );
 
       // assert
-      await assertSingleRecord(
-        schema.oauthState,
-        assertEqualOauthStateTable,
-        expectedState
-      );
+      const actualRecord = await getTypedSingleRecord(schema.oauthState);
+      assertEqualOauthStateTable(expectedState, actualRecord!);
     });
   });
 

--- a/packages/backend/__tests__/infrastructure/repository/UserRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/UserRepository.test.ts
@@ -4,10 +4,10 @@ import { DiscordID, User, UserID } from "../../../src/domain/user/User";
 import { UserRepository } from "../../../src/infrastructure/repositories/UserRepository";
 import { assertEqualUserTable } from "../../testing/table_assert/AssertEqualUserTable";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
+import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
-  insertToDatabase,
-  selectOneFromDatabase
+  insertToDatabase
 } from "../../testing/utils/GenericTableHelper";
 
 describe("UserRepository Tests", () => {
@@ -73,10 +73,11 @@ describe("UserRepository Tests", () => {
       await userRepository.save(user);
 
       // assert
-      const actualRecord = (await selectOneFromDatabase(
-        schema.user
-      )) as typeof schema.user.$inferSelect;
-      assertEqualUserTable(user, actualRecord);
+      await assertSingleRecord(
+        schema.user,
+        assertEqualUserTable,
+        user
+      );
     });
   });
 });

--- a/packages/backend/__tests__/infrastructure/repository/UserRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/UserRepository.test.ts
@@ -4,7 +4,7 @@ import { DiscordID, User, UserID } from "../../../src/domain/user/User";
 import { UserRepository } from "../../../src/infrastructure/repositories/UserRepository";
 import { assertEqualUserTable } from "../../testing/table_assert/AssertEqualUserTable";
 import { createUserTableFixture } from "../../testing/table_fixture/UserTableFixture";
-import { assertSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
+import { getTypedSingleRecord } from "../../testing/utils/DatabaseAssertHelpers";
 import {
   deleteFromDatabase,
   insertToDatabase
@@ -73,11 +73,8 @@ describe("UserRepository Tests", () => {
       await userRepository.save(user);
 
       // assert
-      await assertSingleRecord(
-        schema.user,
-        assertEqualUserTable,
-        user
-      );
+      const actualRecord = await getTypedSingleRecord(schema.user);
+      assertEqualUserTable(user, actualRecord!);
     });
   });
 });

--- a/packages/backend/__tests__/testing/utils/DatabaseAssertHelpers.ts
+++ b/packages/backend/__tests__/testing/utils/DatabaseAssertHelpers.ts
@@ -1,0 +1,64 @@
+import type { InferSelectModel } from "drizzle-orm";
+import type { PgTable } from "drizzle-orm/pg-core";
+import { selectFromDatabase, selectOneFromDatabase } from "./GenericTableHelper";
+
+/**
+ * データベースから単一レコードを取得し、型安全にアサート用ヘルパー関数に渡す
+ * @param table 検索対象のテーブル
+ * @param assertFn アサート関数
+ * @param expectedValue 期待される値
+ */
+export const assertSingleRecord = async <
+  T extends PgTable,
+  TExpected
+>(
+  table: T,
+  assertFn: (expected: TExpected, actual: InferSelectModel<T>) => void,
+  expectedValue: TExpected
+): Promise<void> => {
+  const record = await selectOneFromDatabase(table);
+  if (!record) {
+    throw new Error(`No record found in table ${table}`);
+  }
+  assertFn(expectedValue, record as InferSelectModel<T>);
+};
+
+/**
+ * データベースから複数レコードを取得し、型安全にアサート用ヘルパー関数に渡す
+ * @param table 検索対象のテーブル
+ * @param assertFn アサート関数
+ * @param expectedValue 期待される値
+ */
+export const assertMultipleRecords = async <
+  T extends PgTable,
+  TExpected
+>(
+  table: T,
+  assertFn: (expected: TExpected, actual: InferSelectModel<T>[]) => void,
+  expectedValue: TExpected
+): Promise<void> => {
+  const records = await selectFromDatabase(table);
+  assertFn(expectedValue, records as InferSelectModel<T>[]);
+};
+
+/**
+ * データベースから単一レコードを型安全に取得する
+ * @param table 検索対象のテーブル
+ * @returns 型付きの単一レコード（存在しない場合はnull）
+ */
+export const getTypedSingleRecord = async <T extends PgTable>(
+  table: T
+): Promise<InferSelectModel<T> | null> => {
+  return (await selectOneFromDatabase(table)) as InferSelectModel<T> | null;
+};
+
+/**
+ * データベースから複数レコードを型安全に取得する
+ * @param table 検索対象のテーブル
+ * @returns 型付きのレコード配列
+ */
+export const getTypedMultipleRecords = async <T extends PgTable>(
+  table: T
+): Promise<InferSelectModel<T>[]> => {
+  return (await selectFromDatabase(table)) as InferSelectModel<T>[];
+};

--- a/packages/backend/__tests__/testing/utils/DatabaseAssertHelpers.ts
+++ b/packages/backend/__tests__/testing/utils/DatabaseAssertHelpers.ts
@@ -3,45 +3,6 @@ import type { PgTable } from "drizzle-orm/pg-core";
 import { selectFromDatabase, selectOneFromDatabase } from "./GenericTableHelper";
 
 /**
- * データベースから単一レコードを取得し、型安全にアサート用ヘルパー関数に渡す
- * @param table 検索対象のテーブル
- * @param assertFn アサート関数
- * @param expectedValue 期待される値
- */
-export const assertSingleRecord = async <
-  T extends PgTable,
-  TExpected
->(
-  table: T,
-  assertFn: (expected: TExpected, actual: InferSelectModel<T>) => void,
-  expectedValue: TExpected
-): Promise<void> => {
-  const record = await selectOneFromDatabase(table);
-  if (!record) {
-    throw new Error(`No record found in table ${table}`);
-  }
-  assertFn(expectedValue, record as InferSelectModel<T>);
-};
-
-/**
- * データベースから複数レコードを取得し、型安全にアサート用ヘルパー関数に渡す
- * @param table 検索対象のテーブル
- * @param assertFn アサート関数
- * @param expectedValue 期待される値
- */
-export const assertMultipleRecords = async <
-  T extends PgTable,
-  TExpected
->(
-  table: T,
-  assertFn: (expected: TExpected, actual: InferSelectModel<T>[]) => void,
-  expectedValue: TExpected
-): Promise<void> => {
-  const records = await selectFromDatabase(table);
-  assertFn(expectedValue, records as InferSelectModel<T>[]);
-};
-
-/**
  * データベースから単一レコードを型安全に取得する
  * @param table 検索対象のテーブル
  * @returns 型付きの単一レコード（存在しない場合はnull）


### PR DESCRIPTION
- DatabaseAssertHelpersヘルパー関数を作成
  - assertSingleRecord: 単一レコードのアサーション用
  - assertMultipleRecords: 複数レコードのアサーション用
  - getTypedSingleRecord: 型安全な単一レコード取得
  - getTypedMultipleRecords: 型安全な複数レコード取得

- 冗長な型アサーション (as typeof schema.table.$inferSelect) を削除
- テストコードの可読性とメンテナンス性を向上

対象ファイル:
- CreateAppreciationUseCase.test.ts
- AppreciationRepository.test.ts
- ConsumedPointLogRepository.test.ts
- StateRepository.test.ts
- UserRepository.test.ts
- DiscordTokensRepository.test.ts
- DiscordOAuthFlowService.test.ts

## 変更領域
フロントエンドもしくはバックエンド、または両方を明記してください。

## 背景
なぜこのPRが発生したか・この変更が必要なのかを明記してください

## やったこと
箇条書きでやったことを明記してください

## 動作確認動画(スクリーンショット)
なしであればなしと明記してください

## 確認したこと(デグレチェック)
既存機能に影響がないことを確認した旨を明記してください

## リリース時本番環境で確認すること
リリース前後で確認すべきことを明記してください
